### PR TITLE
Prune navigation and improve feed recovery

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -23,22 +23,19 @@ const MOBILE_TABS = [
   { path: '/feed',    icon: '◉',  label: 'Discover' },
   { path: '/goals',   icon: '◎',  label: 'Goals'    },
   { path: '/ora',     icon: null, label: 'Ora',  isOra: true },
-  { path: '/dao',     icon: '🏛', label: 'DAO'      },
+  { path: '/ioo',     icon: '🗺', label: 'Map'      },
   { path: '/profile', icon: null, label: 'Me',   isProfile: true },
 ] as const;
 
 // ─── Desktop sidebar config ───────────────────────────────────────────────────
 const SIDEBAR_ITEMS = [
-  { path: '/home',     icon: '◉',  label: 'Home'     },
-  { path: '/feed',     icon: '✦',  label: 'Discover' },
-  { path: '/ora',      icon: '◈',  label: 'Ora',     special: true },
-  { path: '/goals',    icon: '◎',  label: 'Goals'    },
-  { path: '/ioo',      icon: '🗺', label: 'Map'      },
-  { path: '/journal',  icon: '✍',  label: 'Journal'  },
-  { path: '/services',   icon: '⚡', label: 'Services'   },
-  { path: '/dao',        icon: '🏛', label: 'DAO'        },
+  { path: '/home',       icon: '◉',  label: 'Home'       },
+  { path: '/feed',       icon: '✦',  label: 'Discover'   },
+  { path: '/ora',        icon: '◈',  label: 'Ora',        special: true },
+  { path: '/goals',      icon: '◎',  label: 'Goals'      },
+  { path: '/ioo',        icon: '🗺', label: 'Map'        },
   { path: '/contribute', icon: '✚',  label: 'Contribute' },
-  { path: '/profile',    icon: null, label: 'Me',        isProfile: true },
+  { path: '/profile',    icon: null, label: 'Me',         isProfile: true },
 ] as const;
 
 const TIER_COLORS: Record<string, string> = {
@@ -56,11 +53,8 @@ export function NavBar() {
 
   // More menu items for Me tab
   const ME_MORE = [
-    { path: '/dao',        icon: '🏛', label: 'DAO & Contributions' },
-    { path: '/contribute', icon: '✚', label: 'Contribute' },
-    { path: '/services',   icon: '⚡', label: 'Services' },
-    { path: '/journal',  icon: '✍', label: 'Journal' },
-    { path: '/home',     icon: '◉', label: 'Home' },
+    { path: '/contribute', icon: '✚', label: 'Contribute & Earn' },
+    { path: '/home',       icon: '◉', label: 'Home' },
   ];
 
   const MAP_MORE = [

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -670,9 +670,30 @@ export default function FeedPage() {
         <div style={{ fontSize: 32 }}>⚠️</div>
         <div style={{ fontSize: 15, fontWeight: 700 }}>Could not load feed</div>
         <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.45)' }}>{error}</div>
-        <button onClick={loadInitial} style={{ background: '#00d4aa', color: '#0a0a0f', padding: '10px 22px', borderRadius: 10, fontWeight: 700 }}>Retry</button>
+        <button
+          onClick={() => loadInitial()}
+          style={{
+            marginTop: 16,
+            background: 'rgba(0,212,170,0.15)',
+            border: '1px solid rgba(0,212,170,0.4)',
+            color: '#00d4aa',
+            padding: '10px 24px',
+            borderRadius: 24,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Try again →
+        </button>
       </div>
     );
+  }
+
+  // If user has no goals and feed is empty, prompt to set a goal
+  if (!cards.length && hasGoals === false) {
+    navigate('/goals');
+    return null;
   }
 
   if (!cards.length) {
@@ -681,14 +702,24 @@ export default function FeedPage() {
         <div style={{ fontSize: 40 }}>◈</div>
         <div style={{ fontWeight: 700, fontSize: 18 }}>Nothing yet</div>
         <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.4)', textAlign: 'center' }}>
-          {hasGoals === false ? 'Add a goal to get personalized cards' : "Ora's preparing your first cards…"}
+          Ora's preparing your first cards…
         </div>
-        {hasGoals === false && (
-          <button onClick={() => { trackEmptyState('click'); navigate('/goals'); }}
-            style={{ background: '#00d4aa', color: '#0a0a0f', padding: '10px 22px', borderRadius: 10, fontWeight: 700 }}>
-            Add a goal →
-          </button>
-        )}
+        <button
+          onClick={() => loadInitial()}
+          style={{
+            marginTop: 12,
+            background: 'rgba(0,212,170,0.15)',
+            border: '1px solid rgba(0,212,170,0.4)',
+            color: '#00d4aa',
+            padding: '10px 24px',
+            borderRadius: 24,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Refresh →
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- hide low-engagement DAO, Services, and Journal entries from mobile/desktop nav while keeping routes intact
- swap mobile DAO tab for the IOO map and simplify the Me more menu
- add retry/refresh actions for feed error and empty states
- redirect users with no goals and an empty feed to Goals setup

## Verification
- npm run build