### PR TITLE
feat: interactive goal clarification with Ora

### DIFF
--- a/src/components/GoalClarifyModal.tsx
+++ b/src/components/GoalClarifyModal.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { OraClient, GoalClarifyMessage } from '../lib/OraClient';
+
+interface GoalClarifyModalProps {
+  goalTitle: string;
+  onClose: () => void;
+  onComplete: (structuredGoal: any, iooPath: any[]) => Promise<void> | void;
+}
+
+interface ChatMessage extends GoalClarifyMessage {
+  id: string;
+}
+
+function OraBubble({ message }: { message: ChatMessage }) {
+  const isOra = message.role === 'ora';
+  return (
+    <div style={{ display: 'flex', flexDirection: isOra ? 'row' : 'row-reverse', gap: 8, marginBottom: 10, alignItems: 'flex-end' }}>
+      {isOra && (
+        <div style={{
+          width: 28, height: 28, borderRadius: 14,
+          background: 'linear-gradient(135deg, rgba(0,212,170,0.2), rgba(0,212,170,0.42))',
+          border: '1px solid rgba(0,212,170,0.45)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 13, flexShrink: 0,
+        }}>◈</div>
+      )}
+      <div style={{
+        maxWidth: '78%',
+        padding: '10px 14px',
+        borderRadius: isOra ? '4px 16px 16px 16px' : '16px 4px 16px 16px',
+        background: isOra ? '#1a1a2e' : 'rgba(0,212,170,0.18)',
+        border: isOra ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(0,212,170,0.35)',
+        color: '#f8f8fc',
+        lineHeight: 1.55,
+        fontSize: 14,
+        whiteSpace: 'pre-wrap',
+      }}>
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+function TypingDots() {
+  return (
+    <div style={{ display: 'flex', gap: 8, marginBottom: 10, alignItems: 'flex-end' }}>
+      <div style={{ width: 28, height: 28, borderRadius: 14, background: 'rgba(0,212,170,0.25)', border: '1px solid rgba(0,212,170,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>◈</div>
+      <div style={{ background: '#1a1a2e', border: '1px solid rgba(255,255,255,0.08)', borderRadius: '4px 16px 16px 16px', padding: '12px 14px', display: 'flex', gap: 5 }}>
+        {[0, 1, 2].map(i => <span key={i} style={{ width: 7, height: 7, borderRadius: 4, background: '#00d4aa', animation: `goalClarifyBounce 1.2s ${i * 0.18}s ease-in-out infinite` }} />)}
+      </div>
+    </div>
+  );
+}
+
+export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: GoalClarifyModalProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([{
+    id: 'opening',
+    role: 'ora',
+    content: `I'd love to help you get ${goalTitle}! Let me ask a few questions to build your perfect plan.`,
+  }]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [structuredGoal, setStructuredGoal] = useState<any>(null);
+  const [iooPath, setIooPath] = useState<any[]>([]);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading, structuredGoal]);
+
+  useEffect(() => {
+    setTimeout(() => inputRef.current?.focus(), 250);
+  }, []);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || loading || structuredGoal) return;
+    const userMessage: ChatMessage = { id: Date.now().toString(), role: 'user', content: text };
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setInput('');
+    setLoading(true);
+
+    try {
+      const conversation = nextMessages.map(({ role, content }) => ({ role, content }));
+      const res = await OraClient.clarifyGoal(goalTitle, conversation);
+      setMessages(prev => [...prev, { id: `${Date.now()}-ora`, role: 'ora', content: res.message }]);
+      if (res.is_complete) {
+        setStructuredGoal(res.structured_goal || { title: goalTitle });
+        setIooPath(res.suggested_ioo_path || []);
+      }
+    } catch (e) {
+      setMessages(prev => [...prev, {
+        id: `${Date.now()}-err`,
+        role: 'ora',
+        content: "I couldn't connect right now. Try again in a moment.",
+      }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startJourney = async () => {
+    if (!structuredGoal || saving) return;
+    setSaving(true);
+    try {
+      await onComplete(structuredGoal, iooPath);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') sendMessage();
+    if (e.key === 'Escape') onClose();
+  };
+
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 1000,
+      background: 'rgba(0,0,0,0.55)',
+      backdropFilter: 'blur(8px)',
+      display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+    }} onClick={onClose}>
+      <div
+        className="goal-clarify-sheet"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 720, maxHeight: '88vh',
+          background: '#0a0a0f',
+          border: '1px solid rgba(0,212,170,0.22)',
+          borderBottom: 'none',
+          borderRadius: '24px 24px 0 0',
+          boxShadow: '0 -20px 80px rgba(0,0,0,0.45)',
+          display: 'flex', flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <div style={{
+          padding: '16px 18px', borderBottom: '1px solid rgba(255,255,255,0.07)',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          background: 'rgba(10,10,15,0.98)',
+        }}>
+          <div>
+            <div style={{ fontSize: 16, fontWeight: 800 }}>Tell Ora about your goal ◈</div>
+            <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.45)', marginTop: 3 }}>{goalTitle}</div>
+          </div>
+          <button onClick={onClose} style={{ background: 'rgba(255,255,255,0.07)', color: 'rgba(248,248,252,0.7)', width: 34, height: 34, borderRadius: 17, fontSize: 18 }}>×</button>
+        </div>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: '16px 16px 8px' }}>
+          {messages.map(msg => <OraBubble key={msg.id} message={msg} />)}
+          {loading && <TypingDots />}
+
+          {structuredGoal && (
+            <div style={{
+              margin: '18px 0 8px', padding: 16,
+              background: 'linear-gradient(180deg, rgba(0,212,170,0.12), rgba(0,212,170,0.05))',
+              border: '1px solid rgba(0,212,170,0.25)',
+              borderRadius: 18,
+            }}>
+              <div style={{ fontWeight: 800, fontSize: 16, marginBottom: 6 }}>Your Path</div>
+              <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.62)', lineHeight: 1.55, marginBottom: 12 }}>
+                {structuredGoal.why || structuredGoal.specifics || 'Ora has shaped this into a clearer, actionable goal.'}
+              </div>
+              {iooPath.length > 0 ? (
+                <div style={{ display: 'grid', gap: 8 }}>
+                  {iooPath.slice(0, 5).map((node, i) => (
+                    <div key={node.id || i} style={{ display: 'flex', gap: 10, padding: 10, borderRadius: 12, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.06)' }}>
+                      <div style={{ width: 24, height: 24, borderRadius: 12, background: '#00d4aa', color: '#0a0a0f', fontSize: 12, fontWeight: 900, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{i + 1}</div>
+                      <div>
+                        <div style={{ fontSize: 13, fontWeight: 700 }}>{node.title || 'First step'}</div>
+                        {node.description && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.5)', lineHeight: 1.45, marginTop: 2 }}>{node.description}</div>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.45)' }}>Ora will generate your first actionable steps when you start.</div>
+              )}
+              <button onClick={startJourney} disabled={saving} style={{
+                width: '100%', marginTop: 14, padding: '13px 16px', borderRadius: 14,
+                background: '#00d4aa', color: '#0a0a0f', fontWeight: 850, fontSize: 15,
+                boxShadow: '0 0 24px rgba(0,212,170,0.22)',
+              }}>
+                {saving ? 'Creating…' : 'Start this journey →'}
+              </button>
+            </div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+
+        {!structuredGoal && (
+          <div style={{ padding: '12px 16px 16px', borderTop: '1px solid rgba(255,255,255,0.07)', background: 'rgba(10,10,15,0.98)' }}>
+            <div style={{ display: 'flex', gap: 10 }}>
+              <input
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Tell Ora…"
+                disabled={loading}
+                style={{ flex: 1, minHeight: 44, borderRadius: 22, padding: '0 15px', background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)', color: '#f8f8fc', outline: 'none' }}
+              />
+              <button onClick={sendMessage} disabled={loading || !input.trim()} style={{ width: 44, height: 44, borderRadius: 22, background: input.trim() ? '#00d4aa' : 'rgba(255,255,255,0.08)', color: input.trim() ? '#0a0a0f' : 'rgba(248,248,252,0.35)', fontWeight: 900 }}>↑</button>
+            </div>
+          </div>
+        )}
+      </div>
+      <style>{`
+        .goal-clarify-sheet { animation: goalClarifySlideUp 220ms ease-out; }
+        @keyframes goalClarifySlideUp { from { transform: translateY(28px); opacity: 0.7; } to { transform: translateY(0); opacity: 1; } }
+        @keyframes goalClarifyBounce { 0%, 80%, 100% { transform: translateY(0); opacity: 0.5; } 40% { transform: translateY(-6px); opacity: 1; } }
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/OraClient.ts
+++ b/src/lib/OraClient.ts
@@ -151,6 +151,18 @@ export interface GoalStep {
   ora_note?: string;
 }
 
+export interface GoalClarifyMessage {
+  role: 'user' | 'ora';
+  content: string;
+}
+
+export interface GoalClarifyResponse {
+  message: string;
+  is_complete: boolean;
+  structured_goal: Record<string, any>;
+  suggested_ioo_path: any[];
+}
+
 export interface FeedbackPayload {
   screen_spec_id: string;
   rating?: number;
@@ -280,9 +292,18 @@ class OraClientClass {
     return res.data as Goal[];
   }
 
-  async createGoal(title: string, description?: string, domain?: string): Promise<Goal> {
-    const res = await this.client.post('/api/goals/', { title, description, domain });
+  async createGoal(title: string, description?: string, domain?: string, steps?: GoalStep[]): Promise<Goal> {
+    const res = await this.client.post('/api/goals/', { title, description, domain, steps });
     return res.data as Goal;
+  }
+
+  async clarifyGoal(goalTitle: string, conversation: GoalClarifyMessage[], userProfile: Record<string, any> = {}): Promise<GoalClarifyResponse> {
+    const res = await this.client.post('/api/goals/clarify', {
+      goal_title: goalTitle,
+      conversation,
+      user_profile: userProfile,
+    });
+    return res.data as GoalClarifyResponse;
   }
 
   async breakdownGoal(goalId: string): Promise<Goal> {

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -3,12 +3,20 @@ import { useSearchParams } from 'react-router-dom';
 import { OraClient, Goal } from '../lib/OraClient';
 import { useToast } from '../components/Toast';
 import { useExperiment } from '../lib/useExperiment';
+import GoalClarifyModal from '../components/GoalClarifyModal';
 
 const DOMAIN_CONFIG: Record<string, { emoji: string; color: string }> = {
   iVive:  { emoji: '🌱', color: '#10b981' },
   Eviva:  { emoji: '🌊', color: '#6366f1' },
   Aventi: { emoji: '✨', color: '#f59e0b' },
 };
+
+const GOAL_STARTERS = [
+  { title: 'Get fit', domain: 'iVive', emoji: '🌱' },
+  { title: 'Feel calmer', domain: 'Eviva', emoji: '🌊' },
+  { title: 'Build a new habit', domain: 'iVive', emoji: '◎' },
+  { title: 'Explore more of life', domain: 'Aventi', emoji: '✨' },
+];
 
 function DomainBadge({ domain }: { domain?: string }) {
   if (!domain) return null;
@@ -385,7 +393,7 @@ function GoalCard({
 }
 
 // Quick inline goal creation bar
-function QuickAddGoal({ onCreate }: { onCreate: (goal: Goal) => void }) {
+function QuickAddGoal({ onClarify }: { onClarify: (title: string) => void }) {
   const [focused, setFocused] = useState(false);
   const [title, setTitle] = useState('');
   const [domain, setDomain] = useState('');
@@ -418,15 +426,14 @@ function QuickAddGoal({ onCreate }: { onCreate: (goal: Goal) => void }) {
     if (!title.trim() || creating) return;
     setCreating(true);
     try {
-      const goal = await OraClient.createGoal(title.trim(), undefined, domain || undefined);
-      trackGoalEvent('goal_created', 1);
-      onCreate(goal);
+      trackGoalEvent('goal_clarification_started', 1);
+      onClarify(title.trim());
       setTitle('');
       setDomain('');
       setFocused(false);
-      show('✦ Goal set!', 'success');
     } catch (e) {
-      console.error('Create goal failed:', e);
+      console.error('Start clarification failed:', e);
+      show('Could not start Ora right now.', 'error');
     } finally {
       setCreating(false);
     }
@@ -519,14 +526,12 @@ function QuickAddGoal({ onCreate }: { onCreate: (goal: Goal) => void }) {
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
+  const [clarifyingGoal, setClarifyingGoal] = useState<string | null>(null);
+  const { show } = useToast();
 
   useEffect(() => {
     OraClient.listGoals().then(setGoals).catch(console.error).finally(() => setLoading(false));
   }, []);
-
-  const handleCreate = (goal: Goal) => {
-    setGoals((prev) => [goal, ...prev]);
-  };
 
   const handleUpdate = (updated: Goal) => {
     setGoals((prev) => prev.map((g) => g.id === updated.id ? updated : g));
@@ -534,6 +539,36 @@ export default function GoalsPage() {
 
   const handleDelete = (id: string) => {
     setGoals((prev) => prev.filter((g) => g.id !== id));
+  };
+
+  const handleClarifiedGoal = async (structuredGoal: any, iooPath: any[]) => {
+    const title = structuredGoal?.title || clarifyingGoal || 'New goal';
+    const descriptionParts = [
+      structuredGoal?.why ? `Why: ${structuredGoal.why}` : null,
+      structuredGoal?.specifics ? `Specifics: ${structuredGoal.specifics}` : null,
+      structuredGoal?.timeline ? `Timeline: ${structuredGoal.timeline}` : null,
+      structuredGoal?.constraints ? `Constraints: ${structuredGoal.constraints}` : null,
+    ].filter(Boolean);
+
+    const steps = iooPath.slice(0, 5).map((node, i) => ({
+      id: node.id || `${Date.now()}-${i}`,
+      text: node.title || `Step ${i + 1}`,
+      detail: node.description,
+      resources: [],
+      completed: false,
+      order: i,
+      ora_note: node.domain ? `IOO path • ${node.domain}` : undefined,
+    }));
+
+    const goal = await OraClient.createGoal(
+      title,
+      descriptionParts.join('\n') || undefined,
+      undefined,
+      steps.length ? steps : undefined,
+    );
+    setGoals((prev) => [goal, ...prev]);
+    setClarifyingGoal(null);
+    show('✦ Goal created!', 'success');
   };
 
   return (
@@ -555,7 +590,27 @@ export default function GoalsPage() {
       </div>
 
       {/* Quick add */}
-      <QuickAddGoal onCreate={handleCreate} />
+      <QuickAddGoal onClarify={setClarifyingGoal} />
+
+      {/* Goal starter cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10, marginBottom: 20 }}>
+        {GOAL_STARTERS.map((starter) => (
+          <button
+            key={starter.title}
+            onClick={() => setClarifyingGoal(starter.title)}
+            style={{
+              textAlign: 'left', padding: 14, borderRadius: 14,
+              background: 'rgba(255,255,255,0.035)',
+              border: '1px solid rgba(255,255,255,0.08)',
+              color: '#f8f8fc',
+            }}
+          >
+            <div style={{ fontSize: 20, marginBottom: 8 }}>{starter.emoji}</div>
+            <div style={{ fontSize: 13, fontWeight: 750 }}>{starter.title}</div>
+            <div style={{ fontSize: 11, color: DOMAIN_CONFIG[starter.domain].color, marginTop: 4 }}>{starter.domain}</div>
+          </button>
+        ))}
+      </div>
 
       {/* Goals list */}
       {loading ? (
@@ -569,7 +624,7 @@ export default function GoalsPage() {
           <div style={{ fontSize: 56, marginBottom: 16, display: 'inline-block' }} className="brain-float">◎</div>
           <div style={{ fontWeight: 700, marginBottom: 8, fontSize: 18 }}>No goals yet</div>
           <div style={{ color: 'rgba(248,248,252,0.4)', maxWidth: 260, margin: '0 auto', lineHeight: 1.6 }}>
-            Tap the field above to add your first goal. Ora will break it into steps.
+            Tap a starter or type your own goal. Ora will clarify it before building your path.
           </div>
         </div>
       ) : (
@@ -578,6 +633,14 @@ export default function GoalsPage() {
             <GoalCard key={goal.id} goal={goal} onUpdate={handleUpdate} onDelete={handleDelete} />
           ))}
         </div>
+      )}
+
+      {clarifyingGoal && (
+        <GoalClarifyModal
+          goalTitle={clarifyingGoal}
+          onClose={() => setClarifyingGoal(null)}
+          onComplete={handleClarifiedGoal}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary\n- Adds a slide-up GoalClarifyModal with Ora-style chat bubbles and path preview\n- Routes quick goal entry and starter/category cards into clarification instead of direct creation\n- Saves the structured goal, including suggested IOO path steps when provided\n\n## Validation\n- npm run build