### PR TITLE
feat: contribution system v2 UI

### DIFF
--- a/src/lib/OraClient.ts
+++ b/src/lib/OraClient.ts
@@ -428,6 +428,7 @@ class OraClientClass {
     github_pr_url?: string;
     external_link?: string;
     evidence_text?: string;
+    attachment_urls?: string[];
   }): Promise<any> {
     const res = await this.client.post('/api/dao/contribute', data);
     return res.data;
@@ -436,6 +437,21 @@ class OraClientClass {
   async getMyContributions(): Promise<any[]> {
     const res = await this.client.get('/api/dao/my-contributions');
     return res.data.contributions;
+  }
+
+  async syncGitHubContributions(): Promise<any> {
+    const res = await this.client.post('/api/dao/sync-github');
+    return res.data;
+  }
+
+  async getContributionStats(): Promise<any> {
+    const res = await this.client.get('/api/users/me/contribution-stats');
+    return res.data;
+  }
+
+  getGitHubConnectUrl(): string {
+    const token = authStorage.getToken();
+    return `${API_URL}/api/auth/github/login?token=${encodeURIComponent(token || '')}`;
   }
 
   // ── Services (Nea-as-Agent-for-Hire) ─────────────────────────────────────

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -1,164 +1,154 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { OraClient, authStorage } from '../lib/OraClient';
+import { OraClient } from '../lib/OraClient';
 
 const ACCENT = '#00d4aa';
 
-type Contribution = {
-  id: string;
-  contribution_type: string;
-  title: string;
-  status: string;
-  cp_awarded?: number;
-};
-
-const contributionTypes = [
-  { value: 'code', label: 'Code', icon: '💻' },
-  { value: 'design', label: 'Design', icon: '🎨' },
-  { value: 'research', label: 'Research', icon: '🔬' },
-  { value: 'content', label: 'Content', icon: '✍' },
-  { value: 'community', label: 'Community', icon: '🤝' },
-  { value: 'idea', label: 'Idea', icon: '💡' },
+const TYPES = [
+  { id: 'code', label: 'Code', icon: '💻', range: '500–1000 CP' },
+  { id: 'design', label: 'Design', icon: '🎨', range: '300–600 CP' },
+  { id: 'research', label: 'Research', icon: '🔬', range: '200–500 CP' },
+  { id: 'content', label: 'Content', icon: '✍️', range: '100–300 CP' },
+  { id: 'community', label: 'Community', icon: '🤝', range: '100–400 CP' },
+  { id: 'idea', label: 'Idea', icon: '💡', range: '50–200 CP' },
 ];
 
-const statusStyles: Record<string, { bg: string; color: string; border: string }> = {
-  pending: { bg: 'rgba(244,194,107,0.13)', color: '#f4c26b', border: 'rgba(244,194,107,0.35)' },
-  approved: { bg: 'rgba(80,220,150,0.13)', color: '#6ff0ad', border: 'rgba(80,220,150,0.32)' },
-  accepted: { bg: 'rgba(80,220,150,0.13)', color: '#6ff0ad', border: 'rgba(80,220,150,0.32)' },
-  rejected: { bg: 'rgba(255,102,102,0.13)', color: '#ff7b7b', border: 'rgba(255,102,102,0.35)' },
+const card: React.CSSProperties = {
+  background: 'linear-gradient(180deg, rgba(18,18,28,0.96), rgba(11,11,17,0.96))',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: 18,
+  padding: 18,
+  boxShadow: '0 18px 60px rgba(0,0,0,0.22)',
 };
 
-const card: React.CSSProperties = {
-  background: 'linear-gradient(180deg, rgba(18,18,26,0.96), rgba(12,12,18,0.96))',
-  border: '1px solid rgba(255,255,255,0.08)',
-  borderRadius: 22,
-  boxShadow: '0 18px 60px rgba(0,0,0,0.24)',
-};
+function StatusBadge({ status }: { status: string }) {
+  const s = String(status || 'pending').toLowerCase();
+  const color = s === 'approved' || s === 'accepted' ? '#34d399' : s === 'rejected' ? '#f87171' : '#f4c26b';
+  return <span style={{ color, border: `1px solid ${color}55`, background: `${color}14`, padding: '3px 8px', borderRadius: 999, fontSize: 11, fontWeight: 800 }}>{s}</span>;
+}
 
 export default function ContributePage() {
-  const [contributions, setContributions] = useState<Contribution[]>([]);
-  const [loadingMine, setLoadingMine] = useState(false);
-  const [type, setType] = useState('code');
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [link, setLink] = useState('');
-  const [evidence, setEvidence] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<'mine' | 'submit' | 'github'>('mine');
+  const [mine, setMine] = useState<any[]>([]);
+  const [stats, setStats] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState('');
+  const [form, setForm] = useState({ contribution_type: 'code', title: '', description: '', external_link: '', attachment_urls: ['', '', ''] });
 
-  const isAuthed = useMemo(() => authStorage.isAuthenticated(), []);
+  const selectedType = useMemo(() => TYPES.find((t) => t.id === form.contribution_type) || TYPES[0], [form.contribution_type]);
 
-  const loadMine = async () => {
-    if (!authStorage.isAuthenticated()) return;
-    setLoadingMine(true);
+  const load = async () => {
+    setLoading(true);
     try {
-      const rows = await OraClient.getMyContributions();
-      setContributions(rows || []);
-    } catch (err) {
-      console.error(err);
+      const [contribs, contributionStats] = await Promise.all([
+        OraClient.getMyContributions().catch(() => []),
+        OraClient.getContributionStats().catch(() => null),
+      ]);
+      setMine(contribs || []);
+      setStats(contributionStats);
+      if (contributionStats?.github_connected) setTab('mine');
     } finally {
-      setLoadingMine(false);
+      setLoading(false);
     }
   };
 
-  useEffect(() => {
-    loadMine();
-  }, []);
+  useEffect(() => { load(); }, []);
+
+  const show = (msg: string) => { setToast(msg); setTimeout(() => setToast(''), 3500); };
+
+  const syncGitHub = async () => {
+    setSyncing(true);
+    try {
+      const res = await OraClient.syncGitHubContributions();
+      show(res.synced ? `Synced ${res.synced} merged PR${res.synced === 1 ? '' : 's'} ✨` : 'No new merged PRs found');
+      await load();
+    } catch (e: any) {
+      show(e?.response?.data?.detail || 'GitHub sync failed');
+    }
+    setSyncing(false);
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setMessage(null);
-    setError(null);
-
-    if (!title.trim() || !description.trim()) {
-      setError('Title and description are required.');
-      return;
-    }
-
-    setSubmitting(true);
+    if (!form.title.trim() || !form.description.trim()) return show('Title and description are required');
+    if (form.description.trim().split(/[.!?]+/).filter(Boolean).length < 3) return show('Please add a little more detail — 3+ sentences helps reviewers.');
+    setSaving(true);
     try {
-      const trimmedLink = link.trim();
       await OraClient.submitContribution({
-        contribution_type: type,
-        title: title.trim(),
-        description: description.trim(),
-        github_pr_url: type === 'code' && trimmedLink ? trimmedLink : undefined,
-        external_link: type !== 'code' && trimmedLink ? trimmedLink : undefined,
-        evidence_text: evidence.trim() || undefined,
+        contribution_type: form.contribution_type,
+        title: form.title.trim(),
+        description: form.description.trim(),
+        external_link: form.external_link.trim() || undefined,
+        github_pr_url: form.contribution_type === 'code' ? form.external_link.trim() || undefined : undefined,
+        attachment_urls: form.attachment_urls.map((u) => u.trim()).filter(Boolean).slice(0, 3),
       });
-      setMessage('Contribution submitted! Ora will review within 24h.');
-      setTitle('');
-      setDescription('');
-      setLink('');
-      setEvidence('');
-      await loadMine();
-    } catch (err: any) {
-      const detail = err?.response?.data?.detail;
-      setError(detail || 'Could not submit contribution. Please sign in and try again.');
-    } finally {
-      setSubmitting(false);
+      setForm({ contribution_type: form.contribution_type, title: '', description: '', external_link: '', attachment_urls: ['', '', ''] });
+      setTab('mine');
+      show('Contribution submitted — Ora will review within 24 hours.');
+      await load();
+    } catch (e: any) {
+      show(e?.response?.data?.detail || 'Submission failed');
     }
+    setSaving(false);
   };
 
   return (
-    <main style={{ minHeight: '100vh', background: 'radial-gradient(circle at 50% 0%, rgba(0,212,170,0.12), transparent 36%), #0a0a0f', color: '#f8f8fc', padding: '46px 18px 110px' }}>
-      <style>{`
-        .contribute-page input, .contribute-page textarea { width: 100%; box-sizing: border-box; background: rgba(255,255,255,0.045); border: 1px solid rgba(255,255,255,0.1); color: #f8f8fc; border-radius: 14px; padding: 14px 15px; font: inherit; outline: none; }
-        .contribute-page input:focus, .contribute-page textarea:focus { border-color: rgba(0,212,170,0.62); box-shadow: 0 0 0 3px rgba(0,212,170,0.10); }
-        .contribute-page label { display: block; color: rgba(248,248,252,0.78); font-size: 13px; font-weight: 800; margin-bottom: 8px; }
-        .contribute-page a { color: ${ACCENT}; text-decoration: none; }
-        .contribute-page a:hover { text-decoration: underline; }
-      `}</style>
-
-      <div className="contribute-page" style={{ maxWidth: 980, margin: '0 auto' }}>
-        <section style={{ textAlign: 'center', marginBottom: 30 }}>
-          <div style={{ display: 'inline-flex', border: '1px solid rgba(0,212,170,0.28)', background: 'rgba(0,212,170,0.08)', color: ACCENT, borderRadius: 999, padding: '7px 12px', fontSize: 12, fontWeight: 900, letterSpacing: 0.9, textTransform: 'uppercase', marginBottom: 16 }}>◈ Ora Contribution Portal</div>
-          <h1 style={{ fontSize: 'clamp(36px, 7vw, 70px)', lineHeight: 0.98, letterSpacing: -2.2, margin: '0 0 16px', fontWeight: 950 }}>Submit work. Earn CP. Shape Ora.</h1>
-          <p style={{ margin: '0 auto', maxWidth: 690, color: 'rgba(248,248,252,0.62)', fontSize: 17, lineHeight: 1.65 }}>Contributions are not just code. Send design work, research, content, community support, ideas, and evidence of useful progress directly to Ora for review.</p>
+    <main style={{ minHeight: '100vh', background: 'radial-gradient(circle at 50% 0%, rgba(0,212,170,0.11), transparent 34%), #0a0a0f', color: '#f8f8fc', padding: '42px 16px 110px' }}>
+      {toast && <div style={{ position: 'fixed', top: 18, left: '50%', transform: 'translateX(-50%)', background: '#12121a', border: '1px solid rgba(0,212,170,0.3)', borderRadius: 12, padding: '10px 14px', zIndex: 10, fontSize: 13 }}>{toast}</div>}
+      <div style={{ maxWidth: 920, margin: '0 auto' }}>
+        <section style={{ textAlign: 'center', marginBottom: 28 }}>
+          <div style={{ display: 'inline-flex', border: '1px solid rgba(0,212,170,0.28)', background: 'rgba(0,212,170,0.08)', color: ACCENT, borderRadius: 999, padding: '7px 12px', fontSize: 12, fontWeight: 900, letterSpacing: 0.8, marginBottom: 16 }}>◈ ORA CONTRIBUTOR SYSTEM</div>
+          <h1 style={{ fontSize: 'clamp(36px, 8vw, 68px)', lineHeight: 0.98, letterSpacing: -2.2, margin: '0 0 14px', fontWeight: 950 }}>Contribute value. Earn CP. Shape Ora.</h1>
+          <p style={{ margin: '0 auto', maxWidth: 680, color: 'rgba(248,248,252,0.62)', fontSize: 16, lineHeight: 1.6 }}>Submit code, design, research, content, community work, or ideas. Code PRs can be synced automatically when GitHub is connected.</p>
         </section>
 
-        <section style={{ ...card, padding: 22, marginBottom: 22 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
-            <div><div style={{ color: ACCENT, fontSize: 12, fontWeight: 900, letterSpacing: 1.1, textTransform: 'uppercase' }}>My Contributions</div><h2 style={{ margin: '5px 0 0', fontSize: 26, letterSpacing: -0.6 }}>Your submitted work</h2></div>
-            {loadingMine && <span style={{ color: 'rgba(248,248,252,0.52)' }}>Loading…</span>}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 18, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {[
+            ['mine', 'My Contributions'], ['submit', 'Submit'], ['github', stats?.github_connected ? 'GitHub Connected' : 'Connect GitHub'],
+          ].map(([id, label]) => (
+            <button key={id} onClick={() => setTab(id as any)} style={{ border: 'none', borderRadius: 12, padding: '10px 14px', fontWeight: 850, cursor: 'pointer', background: tab === id ? ACCENT : 'rgba(255,255,255,0.07)', color: tab === id ? '#06100e' : 'rgba(248,248,252,0.72)' }}>{label}</button>
+          ))}
+        </div>
+
+        {tab === 'mine' && <section style={card}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', marginBottom: 16 }}>
+            <div><h2 style={{ margin: 0, fontSize: 22 }}>My Contributions</h2><div style={{ color: 'rgba(248,248,252,0.45)', fontSize: 13 }}>{stats?.total_cp || 0} CP · {stats?.contributions_approved || 0} approved</div></div>
+            {stats?.github_connected && <button onClick={syncGitHub} disabled={syncing} style={{ background: ACCENT, color: '#06100e', border: 'none', borderRadius: 12, padding: '10px 12px', fontWeight: 900 }}>{syncing ? 'Syncing…' : 'Sync GitHub PRs'}</button>}
           </div>
+          {loading ? <div style={{ color: 'rgba(248,248,252,0.42)' }}>Loading…</div> : mine.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: 32, color: 'rgba(248,248,252,0.48)' }}>You haven’t contributed yet — start below!<br /><button onClick={() => setTab('submit')} style={{ marginTop: 14, background: ACCENT, color: '#06100e', border: 'none', borderRadius: 12, padding: '11px 14px', fontWeight: 900 }}>Submit your first contribution</button></div>
+          ) : mine.map((c) => <div key={c.id} style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '14px 0', display: 'flex', gap: 12, justifyContent: 'space-between' }}><div><div style={{ fontWeight: 850 }}>{c.title}</div><div style={{ fontSize: 12, color: 'rgba(248,248,252,0.45)', marginTop: 4 }}>{c.contribution_type} · {c.source === 'github' ? 'synced from GitHub' : 'manual submission'}</div></div><div style={{ textAlign: 'right' }}><StatusBadge status={c.status} /><div style={{ color: '#f4c26b', fontSize: 12, marginTop: 6 }}>{c.cp_awarded || 0} CP</div></div></div>)}
+        </section>}
 
-          {!isAuthed ? <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)' }}>Sign in to submit contributions and track CP awards.</p> : contributions.length === 0 ? <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)' }}>No submissions yet. Your next contribution can start below.</p> : (
-            <div style={{ display: 'grid', gap: 10 }}>
-              {contributions.map((item) => {
-                const status = statusStyles[item.status] || statusStyles.pending;
-                const typeMeta = contributionTypes.find((t) => t.value === item.contribution_type);
-                const cp = Number(item.cp_awarded || 0);
-                return (
-                  <article key={item.id} style={{ display: 'flex', justifyContent: 'space-between', gap: 14, alignItems: 'center', background: 'rgba(255,255,255,0.035)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 16, padding: '14px 15px', flexWrap: 'wrap' }}>
-                    <div><div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 6, flexWrap: 'wrap' }}><span style={{ color: ACCENT, fontSize: 12, fontWeight: 900, textTransform: 'uppercase' }}>{typeMeta?.icon} {typeMeta?.label || item.contribution_type}</span><span style={{ background: status.bg, color: status.color, border: `1px solid ${status.border}`, borderRadius: 999, padding: '4px 9px', fontSize: 12, fontWeight: 900 }}>{item.status}</span></div><strong style={{ fontSize: 16 }}>{item.title}</strong></div>
-                    {cp > 0 && <div style={{ color: '#f4c26b', fontWeight: 950 }}>{cp} CP</div>}
-                  </article>
-                );
-              })}
-            </div>
-          )}
-        </section>
+        {tab === 'submit' && <form onSubmit={submit} style={{ ...card, display: 'grid', gap: 16 }}>
+          <div><h2 style={{ margin: '0 0 6px', fontSize: 22 }}>Submit a Contribution</h2><p style={{ margin: 0, color: 'rgba(248,248,252,0.48)', fontSize: 13 }}>Be specific. Reviewers reward clear evidence of shipped value.</p></div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(125px, 1fr))', gap: 8 }}>{TYPES.map((t) => <button type="button" key={t.id} onClick={() => setForm({ ...form, contribution_type: t.id })} style={{ border: `1px solid ${form.contribution_type === t.id ? ACCENT : 'rgba(255,255,255,0.08)'}`, background: form.contribution_type === t.id ? 'rgba(0,212,170,0.12)' : '#101018', color: '#f8f8fc', borderRadius: 13, padding: 12, cursor: 'pointer', fontWeight: 800 }}>{t.icon} {t.label}</button>)}</div>
+          <input required placeholder="What did you build/create/do?" value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} style={inputStyle} />
+          <textarea required rows={6} placeholder="Be specific — what exactly did you contribute? What problem does it solve? Why does it matter?" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} style={inputStyle} />
+          <input placeholder="Link: GitHub PR, Figma, Google Doc, YouTube, Notion, etc." value={form.external_link} onChange={(e) => setForm({ ...form, external_link: e.target.value })} style={inputStyle} />
+          {form.attachment_urls.map((url, i) => <input key={i} placeholder={`Attachment URL ${i + 1} — Imgur, Drive, Dropbox, screenshot, mockup…`} value={url} onChange={(e) => { const next = [...form.attachment_urls]; next[i] = e.target.value; setForm({ ...form, attachment_urls: next }); }} style={inputStyle} />)}
+          <div style={{ background: 'rgba(244,194,107,0.08)', border: '1px solid rgba(244,194,107,0.22)', borderRadius: 12, padding: 12, color: '#f4c26b', fontSize: 13, fontWeight: 800 }}>{selectedType.label} contributions typically earn {selectedType.range}</div>
+          <button disabled={saving} style={{ background: ACCENT, color: '#06100e', border: 'none', borderRadius: 14, padding: '14px 16px', fontWeight: 950, cursor: 'pointer' }}>{saving ? 'Submitting…' : 'Submit — Ora reviews within 24 hours'}</button>
+        </form>}
 
-        <section style={{ ...card, padding: 24, marginBottom: 22 }}>
-          <div style={{ marginBottom: 18 }}><div style={{ color: ACCENT, fontSize: 12, fontWeight: 900, letterSpacing: 1.1, textTransform: 'uppercase' }}>Submit a Contribution</div><h2 style={{ margin: '5px 0 0', fontSize: 30, letterSpacing: -0.8 }}>Tell reviewers what you built or moved forward.</h2></div>
-          <form onSubmit={submit} style={{ display: 'grid', gap: 16 }}>
-            <div><label>Contribution type</label><div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>{contributionTypes.map((item) => { const active = type === item.value; return <button key={item.value} type="button" onClick={() => setType(item.value)} style={{ border: active ? '1px solid rgba(0,212,170,0.72)' : '1px solid rgba(255,255,255,0.1)', background: active ? 'rgba(0,212,170,0.14)' : 'rgba(255,255,255,0.04)', color: active ? ACCENT : '#f8f8fc', borderRadius: 999, padding: '10px 13px', fontWeight: 850, cursor: 'pointer' }}>{item.icon} {item.label}</button>; })}</div></div>
-            <div><label htmlFor="contribution-title">Title</label><input id="contribution-title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Short, clear name for your contribution" /></div>
-            <div><label htmlFor="contribution-description">Description *</label><textarea id="contribution-description" value={description} onChange={(e) => setDescription(e.target.value)} rows={6} required placeholder="What did you do? Be specific — reviewers need to understand your contribution." /></div>
-            <div><label htmlFor="contribution-link">Link (optional)</label><input id="contribution-link" value={link} onChange={(e) => setLink(e.target.value)} placeholder="GitHub PR, Figma link, Google Doc, YouTube, etc." /></div>
-            <div><label htmlFor="contribution-evidence">Evidence / context (optional)</label><textarea id="contribution-evidence" value={evidence} onChange={(e) => setEvidence(e.target.value)} rows={4} placeholder="Any additional context, screenshots description, or proof of work." /></div>
-            {message && <div style={{ color: '#6ff0ad', background: 'rgba(80,220,150,0.1)', border: '1px solid rgba(80,220,150,0.25)', borderRadius: 14, padding: 12 }}>{message}</div>}
-            {error && <div style={{ color: '#ff8d8d', background: 'rgba(255,102,102,0.1)', border: '1px solid rgba(255,102,102,0.25)', borderRadius: 14, padding: 12 }}>{error}</div>}
-            <button type="submit" disabled={submitting || !isAuthed} style={{ justifySelf: 'start', minWidth: 210, padding: '14px 18px', borderRadius: 14, border: 'none', background: isAuthed ? `linear-gradient(135deg, ${ACCENT}, #00b896)` : 'rgba(255,255,255,0.12)', color: isAuthed ? '#06100e' : 'rgba(248,248,252,0.55)', fontWeight: 950, cursor: isAuthed ? 'pointer' : 'not-allowed', boxShadow: isAuthed ? '0 12px 34px rgba(0,212,170,0.20)' : 'none' }}>{submitting ? 'Submitting…' : isAuthed ? 'Submit Contribution' : 'Sign in to submit'}</button>
-          </form>
-        </section>
-
-        <details style={{ ...card, padding: 20 }}>
-          <summary style={{ cursor: 'pointer', color: ACCENT, fontWeight: 950, fontSize: 16 }}>How contributions are evaluated</summary>
-          <ul style={{ margin: '16px 0 0', paddingLeft: 20, color: 'rgba(248,248,252,0.66)', lineHeight: 1.75 }}><li>Quality over quantity.</li><li>Must be implemented or documented evidence of real work.</li><li>Ora reviews every submission within 24h.</li><li>CP awarded based on impact and complexity.</li></ul>
-        </details>
+        {tab === 'github' && <section style={{ ...card, textAlign: 'center' }}>
+          {stats?.github_connected ? <>
+            {stats.github_avatar_url && <img src={stats.github_avatar_url} alt="" style={{ width: 72, height: 72, borderRadius: 36, marginBottom: 12 }} />}
+            <h2 style={{ margin: '0 0 6px' }}>GitHub connected</h2>
+            <p style={{ color: 'rgba(248,248,252,0.55)' }}>@{stats.github_username} · merged PRs can be synced automatically.</p>
+            <button onClick={syncGitHub} disabled={syncing} style={{ background: ACCENT, color: '#06100e', border: 'none', borderRadius: 13, padding: '12px 16px', fontWeight: 900 }}>{syncing ? 'Syncing…' : 'Sync now'}</button>
+          </> : <>
+            <h2 style={{ margin: '0 0 8px' }}>Connect GitHub to automatically track merged PRs</h2>
+            <p style={{ maxWidth: 520, margin: '0 auto 18px', color: 'rgba(248,248,252,0.55)', lineHeight: 1.55 }}>When a PR is merged in connectome-backend or connectome-web, Ora can pull it into your contribution list for review — no duplicate manual form needed.</p>
+            <a href={OraClient.getGitHubConnectUrl()} style={{ display: 'inline-flex', background: ACCENT, color: '#06100e', borderRadius: 13, padding: '13px 18px', fontWeight: 950, textDecoration: 'none' }}>Connect GitHub</a>
+          </>}
+        </section>}
       </div>
     </main>
   );
 }
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', background: '#101018', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 13, color: '#f8f8fc', padding: '13px 14px', fontSize: 14, outline: 'none',
+};

--- a/src/pages/DAOPage.tsx
+++ b/src/pages/DAOPage.tsx
@@ -143,13 +143,13 @@ function DAOStatusCard({ cp, tier, rank }: { cp: number; tier: string; rank: num
 function WeeklyLeaderboard({ items }: { items: any[] }) {
   return (
     <div style={{ marginBottom: 20 }}>
-      <div style={{ fontSize: 15, fontWeight: 800, marginBottom: 10 }}>This Week's Builders 🔥</div>
+      <div style={{ fontSize: 15, fontWeight: 800, marginBottom: 10 }}>Top CP Contributors 🔥</div>
       <div style={{ background: '#12121a', border: '1px solid rgba(0,212,170,0.14)', borderRadius: 14, overflow: 'hidden' }}>
         {items.length === 0 ? (
-          <div style={{ padding: 18, textAlign: 'center' as const, color: 'rgba(248,248,252,0.35)', fontSize: 13 }}>No weekly XP yet. Open a PR and light it up.</div>
+          <div style={{ padding: 18, textAlign: 'center' as const, color: 'rgba(248,248,252,0.35)', fontSize: 13 }}>No CP yet. Submit a contribution and light it up.</div>
         ) : items.slice(0, 10).map((item, i) => {
           const rank = item.rank || i + 1;
-          const xp = item.weekly_xp ?? item.xp_this_week ?? item.total_xp ?? item.xp ?? 0;
+          const cp = item.total_cp ?? item.cp_balance ?? item.weekly_cp ?? 0;
           const name = item.display_name || item.name || item.github_username || item.username || 'Builder';
           return (
             <div key={item.id || item.user_id || item.github_username || i} style={{
@@ -158,7 +158,7 @@ function WeeklyLeaderboard({ items }: { items: any[] }) {
             }}>
               <div style={{ width: 30, color: rank <= 3 ? '#fbbf24' : 'rgba(248,248,252,0.35)', fontWeight: 800 }}>#{rank}</div>
               <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 650, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{name}</div>
-              <div style={{ color: '#00d4aa', fontWeight: 800 }}>{Number(xp || 0).toLocaleString()} XP</div>
+              <div style={{ color: '#f4c26b', fontWeight: 800 }}>{Number(cp || 0).toLocaleString()} CP</div>
             </div>
           );
         })}
@@ -455,7 +455,7 @@ export default function DAOPage() {
       if (fs) setFoundingStewards(fs);
       if (contribs) setContributions(contribs.contributions || []);
       if (t) setTasks(t.tasks || []);
-      if (weekly) setWeeklyLeaderboard(weekly.leaderboard || weekly.builders || weekly.results || (Array.isArray(weekly) ? weekly : []));
+      setWeeklyLeaderboard((lb?.leaderboard || []).slice(0, 10));
       if (proposalRes) setProposals(proposalRes.proposals || proposalRes.items || (Array.isArray(proposalRes) ? proposalRes : []));
     }).finally(() => setLoading(false));
   }, []);

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -49,6 +49,7 @@ export default function ProfilePage() {
   const [agentPopulationLoading, setAgentPopulationLoading] = useState(false);
   const [evolutionProposals, setEvolutionProposals] = useState<any[]>([]);
   const [evolutionProposalsLoading, setEvolutionProposalsLoading] = useState(false);
+  const [contributionStats, setContributionStats] = useState<any>(null);
 
   // ── A/B hooks must be BEFORE any conditional returns (Rules of Hooks) ──
   const { variant: upgradeHeadlineVariant, trackEvent: trackUpgradeHeadline } = useExperiment('upgrade_headline');
@@ -60,6 +61,7 @@ export default function ProfilePage() {
     try {
       const p = await OraClient.getProfile();
       setProfile(p);
+      OraClient.getContributionStats().then(setContributionStats).catch(() => {});
       const adminFlag = p?.profile?.is_admin || localStorage.getItem('ab_admin') === 'true';
       setIsAdmin(adminFlag);
       if (adminFlag) localStorage.setItem('ab_admin', 'true');
@@ -345,6 +347,36 @@ export default function ProfilePage() {
             <Row label="Member since" value={profile?.created_at ? new Date(profile.created_at).toLocaleDateString() : '\u2014'} />
             <Row label="Fulfilment score" value={`${((profile?.fulfilment_score || 0) * 100).toFixed(0)}%`} />
             <Row label="Tier" value={tier} valueColor={tierColor} />
+          </Card>
+
+
+
+          {/* ── Contribution Stats ── */}
+          <Card title="Contributions">
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, marginBottom: 12 }}>
+              <StatBox label="Total CP" value={(contributionStats?.total_cp || profile?.profile?.total_dao_cp || 0).toLocaleString()} color="#f4c26b" />
+              <StatBox label="Approved" value={contributionStats?.contributions_approved || 0} color="#34d399" />
+              <StatBox label="XP Rank" value={contributionStats?.weekly_xp_rank ? `#${contributionStats.weekly_xp_rank}` : '—'} color="#00d4aa" />
+            </div>
+            <Row label="Tier" value={contributionStats?.tier || 'observer'} valueColor="#00d4aa" />
+            <Row
+              label="GitHub"
+              value={contributionStats?.github_connected ? `✓ @${contributionStats.github_username}` : 'Connect GitHub →'}
+              valueColor={contributionStats?.github_connected ? '#34d399' : '#00d4aa'}
+            />
+            {contributionStats?.recent_contributions?.length > 0 && (
+              <div style={{ marginTop: 12, borderTop: '1px solid rgba(255,255,255,0.07)', paddingTop: 10 }}>
+                {contributionStats.recent_contributions.slice(0, 3).map((c: any) => (
+                  <div key={c.id} style={{ display: 'flex', justifyContent: 'space-between', gap: 10, fontSize: 12, marginBottom: 8 }}>
+                    <span style={{ color: 'rgba(248,248,252,0.72)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.title}</span>
+                    <span style={{ color: c.status === 'approved' || c.status === 'accepted' ? '#34d399' : '#f4c26b', fontWeight: 700 }}>{c.status}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!contributionStats?.github_connected && (
+              <button onClick={() => { window.location.href = OraClient.getGitHubConnectUrl(); }} style={{ marginTop: 12, background: '#00d4aa', color: '#07110f', border: 'none', borderRadius: 10, padding: '9px 12px', fontWeight: 800 }}>Connect GitHub</button>
+            )}
           </Card>
 
           {/* ── Upgrade prompt for free users ── */}
@@ -1231,6 +1263,15 @@ export default function ProfilePage() {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+function StatBox({ label, value, color }: { label: string; value: any; color: string }) {
+  return (
+    <div style={{ background: 'rgba(255,255,255,0.035)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 12, padding: 10 }}>
+      <div style={{ color, fontWeight: 900, fontSize: 18 }}>{value}</div>
+      <div style={{ color: 'rgba(248,248,252,0.42)', fontSize: 10, marginTop: 2, textTransform: 'uppercase', letterSpacing: 0.6 }}>{label}</div>
+    </div>
+  );
+}
+
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div style={{ background: '#12121e', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 14, padding: '16px 18px' }}>


### PR DESCRIPTION
## Summary
- Rebuilds Contribute page into My Contributions, Submit, and GitHub connection flows
- Adds guided non-code contribution submission with attachment URLs and CP ranges
- Adds profile contribution widget and switches DAO weekly spotlight to CP leaders

## Testing
- npm run build

## Depends on
- Backend PR: https://github.com/AvielCarlos/connectome-backend/pull/13
- Railway env: GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET for GitHub OAuth.