### PR TITLE
feat: update domain cards for three-domain ontology

### DIFF
--- a/src/components/OraCard.tsx
+++ b/src/components/OraCard.tsx
@@ -7,7 +7,7 @@ import { ScreenComponent } from '../lib/OraClient';
 const DOMAIN_CONFIG: Record<string, { emoji: string; color: string }> = {
   iVive:  { emoji: '🌱', color: '#10b981' },
   Eviva:  { emoji: '🌊', color: '#6366f1' },
-  Aventi: { emoji: '✨', color: '#f59e0b' },
+  Aventi: { emoji: '🚀', color: '#f59e0b' },
 };
 
 interface OraCardProps {

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -16,7 +16,6 @@ import { useExperiment } from '../lib/useExperiment';
 const DOMAIN_CONFIG: Record<string, { color: string; gradient: string; emoji: string }> = {
   iVive:   { color: '#10b981', gradient: 'linear-gradient(135deg, #064e3b 0%, #065f46 50%, #0a0a0f 100%)', emoji: '🌱' },
   Eviva:   { color: '#3b82f6', gradient: 'linear-gradient(135deg, #1e3a8a 0%, #1d4ed8 50%, #0a0a0f 100%)', emoji: '🌊' },
-  Animus:  { color: '#a855f7', gradient: 'linear-gradient(135deg, #3b0764 0%, #6b21a8 50%, #0a0a0f 100%)', emoji: '✨' },
   Aventi:  { color: '#f59e0b', gradient: 'linear-gradient(135deg, #451a03 0%, #92400e 50%, #0a0a0f 100%)', emoji: '🚀' },
 };
 const DEFAULT_DOMAIN = { color: '#00d4aa', gradient: 'linear-gradient(135deg, #042f2e 0%, #0f766e 50%, #0a0a0f 100%)', emoji: '◈' };

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -8,7 +8,7 @@ import GoalClarifyModal from '../components/GoalClarifyModal';
 const DOMAIN_CONFIG: Record<string, { emoji: string; color: string }> = {
   iVive:  { emoji: '🌱', color: '#10b981' },
   Eviva:  { emoji: '🌊', color: '#6366f1' },
-  Aventi: { emoji: '✨', color: '#f59e0b' },
+  Aventi: { emoji: '🚀', color: '#f59e0b' },
 };
 
 const GOAL_STARTERS = [

--- a/src/pages/IOOPage.tsx
+++ b/src/pages/IOOPage.tsx
@@ -29,7 +29,7 @@ const TYPE_LABELS: Record<string, string> = {
 const DOMAIN_COLORS: Record<string, string> = {
   iVive:  '#06b6d4',
   Eviva:  '#f43f5e',
-  Animus: '#a855f7',
+  Aventi: '#f59e0b',
 }
 
 interface IOONode {

--- a/src/pages/variants/VariantC.tsx
+++ b/src/pages/variants/VariantC.tsx
@@ -13,7 +13,7 @@ const VARIANT = 'C';
 const DOMAIN_COLORS: Record<string, string> = {
   iVive: '#10b981',
   Eviva: '#3b82f6',
-  Animus: '#a855f7',
+  Aventi: '#f59e0b',
 };
 
 function getDomainColor(domain?: string) {

--- a/src/pages/variants/VariantD.tsx
+++ b/src/pages/variants/VariantD.tsx
@@ -12,7 +12,7 @@ const VARIANT = 'D';
 const DOMAIN_COLORS: Record<string, string> = {
   iVive: '#10b981',
   Eviva: '#3b82f6',
-  Animus: '#a855f7',
+  Aventi: '#f59e0b',
 };
 
 function getDomainColor(spec: any): string {


### PR DESCRIPTION
## Summary\n- removes remaining Animus domain card references\n- updates Aventi iconography to 🚀\n- keeps frontend domain config aligned to iVive, Eviva, and Aventi only\n\n## Validation\n- attempted npm run build; blocked because dependencies are not installed in this clone (tsc: command not found)