### PR TITLE
feat: port contribution UI follow-ups

### DIFF
--- a/src/lib/OraClient.ts
+++ b/src/lib/OraClient.ts
@@ -428,6 +428,7 @@ class OraClientClass {
     github_pr_url?: string;
     external_link?: string;
     evidence_text?: string;
+    attachment_urls?: string[];
   }): Promise<any> {
     const res = await this.client.post('/api/dao/contribute', data);
     return res.data;
@@ -449,6 +450,16 @@ class OraClientClass {
     } catch {
       return { connected: false, github_username: null, github_avatar_url: null };
     }
+  }
+
+  async getContributionStats(): Promise<any> {
+    const res = await this.client.get('/api/users/me/contribution-stats');
+    return res.data;
+  }
+
+  async syncGitHubContributions(): Promise<any> {
+    const res = await this.client.post('/api/dao/sync-github');
+    return res.data;
   }
 
   getGitHubLoginUrl(): string {

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -48,7 +48,9 @@ export default function ContributePage() {
   const [description, setDescription] = useState('');
   const [link, setLink] = useState('');
   const [evidence, setEvidence] = useState('');
+  const [attachmentUrls, setAttachmentUrls] = useState(['', '', '']);
   const [submitting, setSubmitting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [githubStatus, setGithubStatus] = useState<GitHubStatus>({ connected: false, github_username: null, github_avatar_url: null });
@@ -72,6 +74,22 @@ export default function ContributePage() {
     loadMine();
     OraClient.getGitHubStatus().then(setGithubStatus);
   }, []);
+
+  const syncGitHub = async () => {
+    setMessage(null);
+    setError(null);
+    setSyncing(true);
+    try {
+      const res = await OraClient.syncGitHubContributions();
+      const count = Number(res?.synced || 0);
+      setMessage(count > 0 ? `Synced ${count} merged PR${count === 1 ? '' : 's'} from GitHub.` : 'No new merged PRs found on GitHub.');
+      await loadMine();
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Could not sync GitHub contributions.');
+    } finally {
+      setSyncing(false);
+    }
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -98,12 +116,14 @@ export default function ContributePage() {
         github_pr_url: type === 'code' && trimmedLink ? trimmedLink : undefined,
         external_link: type !== 'code' && trimmedLink ? trimmedLink : undefined,
         evidence_text: evidence.trim() || undefined,
+        attachment_urls: attachmentUrls.map((url) => url.trim()).filter(Boolean),
       });
       setMessage('Contribution submitted! Ora will review within 24h.');
       setTitle('');
       setDescription('');
       setLink('');
       setEvidence('');
+      setAttachmentUrls(['', '', '']);
       await loadMine();
     } catch (err: any) {
       const detail = err?.response?.data?.detail;
@@ -133,7 +153,7 @@ export default function ContributePage() {
         <section style={{ ...card, padding: 22, marginBottom: 22 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
             <div><div style={{ color: ACCENT, fontSize: 12, fontWeight: 900, letterSpacing: 1.1, textTransform: 'uppercase' }}>My Contributions</div><h2 style={{ margin: '5px 0 0', fontSize: 26, letterSpacing: -0.6 }}>Your submitted work</h2></div>
-            {loadingMine && <span style={{ color: 'rgba(248,248,252,0.52)' }}>Loading…</span>}
+            {githubStatus.connected ? <button type="button" onClick={syncGitHub} disabled={syncing} style={{ border: 'none', background: syncing ? 'rgba(255,255,255,0.12)' : `linear-gradient(135deg, ${ACCENT}, #00b896)`, color: syncing ? 'rgba(248,248,252,0.55)' : '#06100e', borderRadius: 12, padding: '10px 13px', fontWeight: 900, cursor: syncing ? 'not-allowed' : 'pointer' }}>{syncing ? 'Syncing…' : 'Sync GitHub PRs'}</button> : loadingMine && <span style={{ color: 'rgba(248,248,252,0.52)' }}>Loading…</span>}
           </div>
 
           {!isAuthed ? <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)' }}>Sign in to submit contributions and track CP awards.</p> : contributions.length === 0 ? <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)' }}>No submissions yet. Your next contribution can start below.</p> : (
@@ -179,6 +199,7 @@ export default function ContributePage() {
             <div><label htmlFor="contribution-description">Description *</label><textarea id="contribution-description" value={description} onChange={(e) => setDescription(e.target.value)} rows={6} required placeholder="What did you do? Be specific — reviewers need to understand your contribution." /></div>
             <div><label htmlFor="contribution-link">Link (optional)</label><input id="contribution-link" value={link} onChange={(e) => setLink(e.target.value)} placeholder="GitHub PR, Figma link, Google Doc, YouTube, etc." /></div>
             <div><label htmlFor="contribution-evidence">Evidence / context (optional)</label><textarea id="contribution-evidence" value={evidence} onChange={(e) => setEvidence(e.target.value)} rows={4} placeholder="Any additional context, screenshots description, or proof of work." /></div>
+            <div><label>Attachment URLs (optional)</label><div style={{ display: 'grid', gap: 10 }}>{attachmentUrls.map((url, i) => <input key={i} value={url} onChange={(e) => { const next = [...attachmentUrls]; next[i] = e.target.value; setAttachmentUrls(next); }} placeholder={`Screenshot, Drive, Figma, Loom, or proof URL ${i + 1}`} />)}</div></div>
             {!githubStatus.connected && type !== 'code' && (
               <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.4)', marginTop: 8, textAlign: 'center' }}>
                 <a href={OraClient.getGitHubLoginUrl()} style={{ color: '#00d4aa', textDecoration: 'none' }}>

--- a/src/pages/DAOPage.tsx
+++ b/src/pages/DAOPage.tsx
@@ -143,13 +143,13 @@ function DAOStatusCard({ cp, tier, rank }: { cp: number; tier: string; rank: num
 function WeeklyLeaderboard({ items }: { items: any[] }) {
   return (
     <div style={{ marginBottom: 20 }}>
-      <div style={{ fontSize: 15, fontWeight: 800, marginBottom: 10 }}>This Week's Builders 🔥</div>
+      <div style={{ fontSize: 15, fontWeight: 800, marginBottom: 10 }}>Top CP Contributors 🔥</div>
       <div style={{ background: '#12121a', border: '1px solid rgba(0,212,170,0.14)', borderRadius: 14, overflow: 'hidden' }}>
         {items.length === 0 ? (
-          <div style={{ padding: 18, textAlign: 'center' as const, color: 'rgba(248,248,252,0.35)', fontSize: 13 }}>No weekly XP yet. Open a PR and light it up.</div>
+          <div style={{ padding: 18, textAlign: 'center' as const, color: 'rgba(248,248,252,0.35)', fontSize: 13 }}>No CP yet. Submit a contribution and light it up.</div>
         ) : items.slice(0, 10).map((item, i) => {
           const rank = item.rank || i + 1;
-          const xp = item.weekly_xp ?? item.xp_this_week ?? item.total_xp ?? item.xp ?? 0;
+          const cp = item.total_cp ?? item.cp_balance ?? item.weekly_cp ?? item.weekly_xp ?? item.xp_this_week ?? item.total_xp ?? item.xp ?? 0;
           const name = item.display_name || item.name || item.github_username || item.username || 'Builder';
           return (
             <div key={item.id || item.user_id || item.github_username || i} style={{
@@ -158,7 +158,7 @@ function WeeklyLeaderboard({ items }: { items: any[] }) {
             }}>
               <div style={{ width: 30, color: rank <= 3 ? '#fbbf24' : 'rgba(248,248,252,0.35)', fontWeight: 800 }}>#{rank}</div>
               <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 650, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{name}</div>
-              <div style={{ color: '#00d4aa', fontWeight: 800 }}>{Number(xp || 0).toLocaleString()} XP</div>
+              <div style={{ color: '#f4c26b', fontWeight: 800 }}>{Number(cp || 0).toLocaleString()} CP</div>
             </div>
           );
         })}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -49,6 +49,7 @@ export default function ProfilePage() {
   const [agentPopulationLoading, setAgentPopulationLoading] = useState(false);
   const [evolutionProposals, setEvolutionProposals] = useState<any[]>([]);
   const [evolutionProposalsLoading, setEvolutionProposalsLoading] = useState(false);
+  const [contributionStats, setContributionStats] = useState<any>(null);
 
   // ── A/B hooks must be BEFORE any conditional returns (Rules of Hooks) ──
   const { variant: upgradeHeadlineVariant, trackEvent: trackUpgradeHeadline } = useExperiment('upgrade_headline');
@@ -60,6 +61,7 @@ export default function ProfilePage() {
     try {
       const p = await OraClient.getProfile();
       setProfile(p);
+      OraClient.getContributionStats().then(setContributionStats).catch(() => {});
       const adminFlag = p?.profile?.is_admin || localStorage.getItem('ab_admin') === 'true';
       setIsAdmin(adminFlag);
       if (adminFlag) localStorage.setItem('ab_admin', 'true');
@@ -345,6 +347,33 @@ export default function ProfilePage() {
             <Row label="Member since" value={profile?.created_at ? new Date(profile.created_at).toLocaleDateString() : '\u2014'} />
             <Row label="Fulfilment score" value={`${((profile?.fulfilment_score || 0) * 100).toFixed(0)}%`} />
             <Row label="Tier" value={tier} valueColor={tierColor} />
+          </Card>
+
+          <Card title="Contributions">
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, marginBottom: 12 }}>
+              <StatBox label="Total CP" value={(contributionStats?.total_cp || profile?.profile?.total_dao_cp || 0).toLocaleString()} color="#f4c26b" />
+              <StatBox label="Approved" value={contributionStats?.contributions_approved || 0} color="#34d399" />
+              <StatBox label="Rank" value={contributionStats?.weekly_xp_rank ? `#${contributionStats.weekly_xp_rank}` : '—'} color="#00d4aa" />
+            </div>
+            <Row label="Contributor tier" value={contributionStats?.tier || 'observer'} valueColor="#00d4aa" />
+            <Row
+              label="GitHub"
+              value={contributionStats?.github_connected ? `✓ @${contributionStats.github_username}` : 'Not connected'}
+              valueColor={contributionStats?.github_connected ? '#34d399' : 'rgba(248,248,252,0.45)'}
+            />
+            {contributionStats?.recent_contributions?.length > 0 && (
+              <div style={{ marginTop: 12, borderTop: '1px solid rgba(255,255,255,0.07)', paddingTop: 10 }}>
+                {contributionStats.recent_contributions.slice(0, 3).map((c: any) => (
+                  <div key={c.id} style={{ display: 'flex', justifyContent: 'space-between', gap: 10, fontSize: 12, marginBottom: 8 }}>
+                    <span style={{ color: 'rgba(248,248,252,0.72)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.title}</span>
+                    <span style={{ color: c.status === 'approved' || c.status === 'accepted' ? '#34d399' : '#f4c26b', fontWeight: 700 }}>{c.status}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!contributionStats?.github_connected && (
+              <button onClick={() => { window.location.href = OraClient.getGitHubLoginUrl(); }} style={{ marginTop: 12, background: '#00d4aa', color: '#07110f', border: 'none', borderRadius: 10, padding: '9px 12px', fontWeight: 800 }}>Connect GitHub</button>
+            )}
           </Card>
 
           {/* ── Upgrade prompt for free users ── */}
@@ -1231,6 +1260,15 @@ export default function ProfilePage() {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+function StatBox({ label, value, color }: { label: string; value: React.ReactNode; color: string }) {
+  return (
+    <div style={{ background: 'rgba(255,255,255,0.035)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 12, padding: 10 }}>
+      <div style={{ color, fontWeight: 900, fontSize: 18 }}>{value}</div>
+      <div style={{ color: 'rgba(248,248,252,0.42)', fontSize: 10, marginTop: 2, textTransform: 'uppercase', letterSpacing: 0.6 }}>{label}</div>
+    </div>
+  );
+}
+
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div style={{ background: '#12121e', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 14, padding: '16px 18px' }}>


### PR DESCRIPTION
## Summary\n- Ports the non-duplicative useful pieces from stale PR #7 onto current main\n- Preserves the current ContributePage GitHub contribution gate from #8\n- Adds attachment URL submission UX, GitHub PR sync action, contribution stats/profile card, and CP-oriented DAO leaderboard copy\n- Leaves the current three-domain ontology UI from #9 untouched\n\n## Test\n- npm run build\n\nSupersedes #7.