### PR TITLE
feat: add Connectome AIOS shell

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -350,3 +350,482 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   background-size: 200% 200%;
   animation: gradShimmer 5s ease infinite;
 }
+
+/* ─── Connectome AIOS shell ───────────────────────────────────────── */
+:root {
+  --bg: #060610;
+  --surface: rgba(16, 17, 31, 0.78);
+  --surface2: rgba(27, 29, 50, 0.76);
+  --border: rgba(255, 255, 255, 0.1);
+  --bottom-nav-height: 92px;
+  --top-header-height: 72px;
+}
+
+body {
+  background:
+    radial-gradient(circle at 50% -15%, rgba(0, 212, 170, 0.18), transparent 34rem),
+    radial-gradient(circle at 12% 20%, rgba(99, 102, 241, 0.14), transparent 28rem),
+    #060610;
+  font-size: clamp(15px, 2.2vw, 17px);
+}
+
+.connectome-shell {
+  position: relative;
+  min-height: 100vh;
+  isolation: isolate;
+  overflow-x: hidden;
+  color: #f8f8fc;
+  background:
+    linear-gradient(180deg, rgba(6, 6, 16, 0.58), #060610 48%),
+    radial-gradient(circle at 82% 18%, rgba(0, 212, 170, 0.12), transparent 24rem);
+}
+
+.connectome-stars {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.42;
+  background-image:
+    radial-gradient(circle, rgba(255,255,255,0.42) 1px, transparent 1px),
+    radial-gradient(circle, rgba(0,212,170,0.28) 1px, transparent 1px);
+  background-size: 68px 68px, 113px 113px;
+  background-position: 0 0, 24px 36px;
+}
+
+.connectome-topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 90;
+  height: var(--top-header-height);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: max(10px, env(safe-area-inset-top)) 18px 10px;
+  background: linear-gradient(180deg, rgba(6, 6, 16, 0.92), rgba(6, 6, 16, 0.58));
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.connectome-brand,
+.connectome-ora-indicator,
+.connectome-status button,
+.connectome-dock__item {
+  background: transparent;
+  color: inherit;
+}
+
+.connectome-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  justify-self: start;
+  min-height: 44px;
+  text-align: left;
+}
+
+.connectome-brand__glyph {
+  width: 38px;
+  height: 38px;
+  border-radius: 15px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(0,212,170,0.34);
+  background: rgba(0,212,170,0.08);
+  box-shadow: 0 0 26px rgba(0,212,170,0.14);
+  color: #00d4aa;
+  font-size: 22px;
+}
+
+.connectome-brand strong { display: block; font-size: 16px; letter-spacing: -0.04em; }
+.connectome-brand small { display: block; margin-top: 1px; color: rgba(248,248,252,0.42); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+
+.connectome-ora-indicator {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 0 16px;
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 999px;
+  background: rgba(255,255,255,0.035);
+  color: rgba(248,248,252,0.72);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.ora-orb {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  display: inline-block;
+  background: radial-gradient(circle at 35% 30%, #eafffb, #00d4aa 38%, #0d7768 74%);
+  box-shadow: 0 0 18px rgba(0,212,170,0.9), 0 0 44px rgba(0,212,170,0.35);
+  animation: oraPulse 2.8s ease-in-out infinite;
+}
+
+.ora-orb--large { width: 34px; height: 34px; }
+.ora-orb--small { width: 22px; height: 22px; }
+
+@keyframes oraPulse {
+  0%, 100% { transform: scale(1); filter: saturate(1); opacity: 0.82; }
+  50% { transform: scale(1.18); filter: saturate(1.4); opacity: 1; }
+}
+
+.connectome-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.connectome-xp,
+.connectome-bell,
+.connectome-avatar {
+  min-height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.09);
+  background: rgba(255,255,255,0.04) !important;
+}
+
+.connectome-xp {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  color: #00d4aa;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+}
+
+.connectome-bell { width: 38px; }
+.connectome-avatar { width: 38px; color: #f8f8fc; font-weight: 900; }
+
+.connectome-main {
+  position: relative;
+  min-height: 100vh;
+  padding: calc(var(--top-header-height) + 18px) clamp(16px, 4vw, 44px) calc(var(--bottom-nav-height) + 28px);
+}
+
+.connectome-main--ido {
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+}
+
+.connectome-app-titlebar {
+  position: fixed;
+  top: calc(var(--top-header-height) + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 35;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(8, 9, 20, 0.72);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 10px 36px rgba(0,0,0,0.28);
+}
+
+.connectome-app-titlebar span { font-weight: 900; letter-spacing: -0.02em; }
+.connectome-app-titlebar small { color: rgba(248,248,252,0.48); font-size: 12px; white-space: nowrap; }
+
+.connectome-dock {
+  position: fixed;
+  left: 50%;
+  bottom: max(14px, env(safe-area-inset-bottom));
+  z-index: 95;
+  transform: translateX(-50%);
+  width: min(520px, calc(100vw - 24px));
+  height: 72px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  padding: 8px;
+  border-radius: 28px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(10, 11, 24, 0.74);
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+  box-shadow: 0 18px 70px rgba(0,0,0,0.48), inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.connectome-dock__item {
+  min-height: 54px;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  color: rgba(248,248,252,0.5);
+}
+
+.connectome-dock__item span { font-size: 21px; line-height: 1; }
+.connectome-dock__item small { font-size: 10px; font-weight: 700; letter-spacing: 0.02em; }
+
+.connectome-dock__item--active,
+.connectome-dock__item:hover {
+  color: #f8f8fc;
+  background: rgba(0,212,170,0.1);
+  box-shadow: 0 0 28px rgba(0,212,170,0.18), inset 0 0 0 1px rgba(0,212,170,0.18);
+}
+
+.connectome-dock__item--ora span {
+  color: #00d4aa;
+  text-shadow: 0 0 18px rgba(0,212,170,0.8);
+}
+
+.connectome-signout {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 20;
+  min-height: 32px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(248,248,252,0.24);
+  font-size: 11px;
+}
+
+.connectome-loading {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  color: rgba(248,248,252,0.54);
+  background: #060610;
+}
+
+.connectome-home {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.connectome-home__hero {
+  min-height: 34vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: clamp(26px, 6vw, 64px);
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 36px;
+  background:
+    radial-gradient(circle at 75% 25%, rgba(0,212,170,0.22), transparent 20rem),
+    linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.025));
+  box-shadow: 0 24px 90px rgba(0,0,0,0.28);
+}
+
+.connectome-home__signal,
+.connectome-home__highlight span,
+.connectome-home__activity span,
+.app-launcher__intro span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #00d4aa;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.connectome-home h1 {
+  margin-top: 18px;
+  max-width: 780px;
+  font-size: clamp(38px, 8vw, 82px);
+  line-height: 0.94;
+  letter-spacing: -0.08em;
+}
+
+.connectome-home__hero p {
+  margin-top: 18px;
+  color: rgba(248,248,252,0.62);
+  font-size: clamp(18px, 3vw, 24px);
+}
+
+.connectome-home__highlights {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+.connectome-home__highlight,
+.connectome-home__activity,
+.app-launcher__card {
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.028));
+  box-shadow: 0 20px 60px rgba(0,0,0,0.18);
+}
+
+.connectome-home__highlight { padding: 22px; }
+.connectome-home__highlight h3 { margin-top: 14px; font-size: 20px; line-height: 1.18; letter-spacing: -0.04em; }
+.connectome-home__highlight p { margin-top: 10px; color: rgba(248,248,252,0.46); font-size: 14px; }
+
+.connectome-home__apps {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.connectome-home__apps button {
+  min-width: 136px;
+  min-height: 104px;
+  padding: 16px;
+  border-radius: 26px;
+  background: rgba(255,255,255,0.055);
+  color: #f8f8fc;
+  border: 1px solid rgba(255,255,255,0.08);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.connectome-home__apps span { font-size: 28px; }
+.connectome-home__apps strong { font-size: 15px; }
+
+.connectome-home__activity { padding: 26px; }
+.connectome-home__activity h2 { margin: 8px 0 18px; letter-spacing: -0.04em; }
+.connectome-home__activity p { padding: 14px 0; border-top: 1px solid rgba(255,255,255,0.06); color: rgba(248,248,252,0.65); }
+
+.connectome-launcher-sheet,
+.ora-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 180;
+}
+
+.connectome-launcher-sheet {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0,0,0,0.52);
+  backdrop-filter: blur(12px);
+}
+
+.connectome-launcher-sheet__panel {
+  position: relative;
+  width: min(880px, 100%);
+  max-height: min(82vh, 760px);
+  overflow: auto;
+  border-radius: 34px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(9, 10, 22, 0.92);
+  box-shadow: 0 24px 90px rgba(0,0,0,0.58);
+}
+
+.connectome-launcher-sheet__close,
+.ora-overlay__close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 2;
+  width: 42px;
+  height: 42px;
+  min-height: 42px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.08);
+  color: #f8f8fc;
+  font-size: 24px;
+}
+
+.app-launcher { padding: clamp(24px, 5vw, 42px); }
+.app-launcher__intro h2 { margin-top: 8px; font-size: clamp(28px, 5vw, 46px); line-height: 1; letter-spacing: -0.07em; }
+.app-launcher__grid { margin-top: 26px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.app-launcher__card { min-height: 188px; padding: 22px; text-align: left; color: #f8f8fc; display: flex; flex-direction: column; align-items: flex-start; }
+.app-launcher__card:hover { transform: translateY(-3px); border-color: rgba(0,212,170,0.28); }
+.app-launcher__icon { font-size: 34px; }
+.app-launcher__name { margin-top: 18px; font-size: 21px; font-weight: 900; letter-spacing: -0.04em; }
+.app-launcher__description { margin-top: 8px; color: rgba(248,248,252,0.55); font-size: 14px; line-height: 1.45; }
+.app-launcher__soon { margin-top: auto; color: #00d4aa; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.ora-overlay { display: grid; place-items: center; padding: 18px; }
+.ora-overlay__scrim { position: absolute; inset: 0; background: rgba(2,3,10,0.58); backdrop-filter: blur(16px); }
+.ora-overlay__panel {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  height: min(820px, calc(100vh - 36px));
+  border: 1px solid rgba(255,255,255,0.14);
+  border-radius: 36px;
+  background: linear-gradient(145deg, rgba(14,16,32,0.86), rgba(6,7,18,0.78));
+  backdrop-filter: blur(34px);
+  box-shadow: 0 32px 120px rgba(0,0,0,0.68), inset 0 1px 0 rgba(255,255,255,0.08);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.ora-overlay__header { position: relative; padding: 18px 22px 14px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+.ora-overlay__handle { width: 44px; height: 4px; margin: 0 auto 14px; border-radius: 999px; background: rgba(255,255,255,0.24); }
+.ora-overlay__identity { display: flex; align-items: center; gap: 14px; }
+.ora-overlay__eyebrow { color: rgba(248,248,252,0.42); font-size: 11px; text-transform: uppercase; letter-spacing: 0.15em; font-weight: 800; }
+.ora-overlay__identity h2 { margin: 2px 0 0; font-size: 30px; letter-spacing: -0.06em; }
+.ora-overlay__messages { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+.ora-overlay__message { display: flex; align-items: flex-end; gap: 10px; }
+.ora-overlay__message > div { max-width: min(72%, 520px); padding: 13px 16px; border-radius: 20px; line-height: 1.55; font-size: 15px; }
+.ora-overlay__message--ora > div { background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.08); border-bottom-left-radius: 6px; }
+.ora-overlay__message--user { justify-content: flex-end; }
+.ora-overlay__message--user > div { background: rgba(0,212,170,0.16); border: 1px solid rgba(0,212,170,0.28); border-bottom-right-radius: 6px; }
+.ora-overlay__typing { display: flex; gap: 5px; }
+.ora-overlay__typing span { width: 7px; height: 7px; border-radius: 999px; background: #00d4aa; animation: bounce 1.2s ease-in-out infinite; }
+.ora-overlay__typing span:nth-child(2) { animation-delay: 0.15s; }
+.ora-overlay__typing span:nth-child(3) { animation-delay: 0.3s; }
+.ora-overlay__quick-actions { display: flex; gap: 8px; overflow-x: auto; padding: 0 20px 14px; }
+.ora-overlay__quick-actions button { flex: 0 0 auto; min-height: 38px; padding: 0 14px; border-radius: 999px; background: rgba(255,255,255,0.07); color: rgba(248,248,252,0.78); border: 1px solid rgba(255,255,255,0.08); font-size: 13px; }
+.ora-overlay__composer { display: flex; gap: 10px; padding: 16px 20px max(18px, env(safe-area-inset-bottom)); border-top: 1px solid rgba(255,255,255,0.08); }
+.ora-overlay__composer input { border-radius: 999px; background: rgba(255,255,255,0.07); }
+.ora-overlay__composer button { min-width: 82px; border-radius: 999px; background: #00d4aa; color: #04110f; }
+
+/* Reframe legacy full-screen pages inside the AIOS chrome. */
+.feed-container {
+  top: var(--top-header-height) !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: var(--bottom-nav-height) !important;
+}
+.ora-container {
+  top: var(--top-header-height) !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: var(--bottom-nav-height) !important;
+}
+
+@media (min-width: 1024px) {
+  .app-authenticated { padding-left: 0; }
+  .feed-container,
+  .ora-container { left: 0 !important; bottom: var(--bottom-nav-height) !important; }
+}
+
+@media (max-width: 760px) {
+  .connectome-topbar { grid-template-columns: auto 1fr auto; padding-left: 12px; padding-right: 12px; }
+  .connectome-brand small,
+  .connectome-ora-indicator span:last-child,
+  .connectome-xp,
+  .connectome-app-titlebar small,
+  .connectome-signout { display: none; }
+  .connectome-brand strong { font-size: 14px; }
+  .connectome-main { padding-left: 14px; padding-right: 14px; }
+  .connectome-home__hero { min-height: 30vh; border-radius: 28px; }
+  .connectome-home__highlights,
+  .app-launcher__grid { grid-template-columns: 1fr; }
+  .connectome-home h1 { font-size: clamp(36px, 14vw, 62px); }
+  .ora-overlay { padding: 0; align-items: stretch; }
+  .ora-overlay__panel { width: 100%; height: 100%; border-radius: 0; border-left: none; border-right: none; }
+  .ora-overlay__message > div { max-width: 82%; }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,61 +3,78 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import { ToastProvider } from './components/Toast'
-import { NavBar } from './components/NavBar'
-import SuggestionButton from './components/SuggestionButton'
-import OraOnboarding from './components/OraOnboarding'
+import ConnectomeShell from './shell/ConnectomeShell'
 import './index.css'
 
 // Eagerly load auth pages (small, needed immediately)
 import AuthPage from './pages/AuthPage'
 import AuthCallbackPage from './pages/AuthCallbackPage'
 import GitHubCallbackPage from './pages/GitHubCallbackPage'
+import ConnectomeHome from './pages/ConnectomeHome'
 
 // Lazy-load all app pages for route-level code splitting
 const FeedPage = lazy(() => import('./pages/FeedPage'))
-const LandingRouter = lazy(() => import('./pages/LandingRouter'))
 const GoalsPage = lazy(() => import('./pages/GoalsPage'))
 const JournalPage = lazy(() => import('./pages/JournalPage'))
-const OraPage = lazy(() => import('./pages/OraPage'))
 const DAOPage = lazy(() => import('./pages/DAOPage'))
 const ContributePage = lazy(() => import('./pages/ContributePage'))
 const ServicesPage = lazy(() => import('./pages/ServicesPage'))
 const ProfilePage = lazy(() => import('./pages/ProfilePage'))
 const SurfacePage = lazy(() => import('./pages/SurfacePage'))
-const HomePage = lazy(() => import('./pages/HomePage'))
 const IOOPage = lazy(() => import('./pages/IOOPage'))
+
+type ShellApp = React.ComponentProps<typeof ConnectomeShell>['activeApp']
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
   return isAuthenticated ? <>{children}</> : <Navigate to="/" replace />
 }
 
+function ShellRoute({ activeApp, children }: { activeApp: ShellApp; children: React.ReactNode }) {
+  return (
+    <ProtectedRoute>
+      <ConnectomeShell activeApp={activeApp}>{children}</ConnectomeShell>
+    </ProtectedRoute>
+  )
+}
+
 function App() {
   const { isAuthenticated } = useAuth()
   return (
-    <div className={isAuthenticated ? 'app-authenticated' : undefined} style={{ minHeight: '100vh', background: '#0a0a0f', color: '#f8f8fc' }}>
-      {isAuthenticated && <NavBar />}
-      {isAuthenticated && <SuggestionButton />}
-      {isAuthenticated && <OraOnboarding />}
-      <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh', color: '#888' }}>Loading…</div>}>
+    <div style={{ minHeight: '100vh', background: '#060610', color: '#f8f8fc' }}>
+      <Suspense fallback={<div className="connectome-loading">Loading…</div>}>
         <Routes>
-          <Route path="/" element={isAuthenticated ? <Navigate to="/home" replace /> : <AuthPage />} />
-          <Route path="/home" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
+          <Route path="/" element={isAuthenticated ? <ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute> : <AuthPage />} />
           {/* Google OAuth callback — must be accessible without auth */}
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
           <Route path="/auth/github-callback" element={<GitHubCallbackPage />} />
-          <Route path="/feed"    element={<ProtectedRoute><FeedPage /></ProtectedRoute>} />
-          <Route path="/discover" element={<ProtectedRoute><LandingRouter /></ProtectedRoute>} />
-          <Route path="/goals"   element={<ProtectedRoute><GoalsPage /></ProtectedRoute>} />
-          <Route path="/journal" element={<ProtectedRoute><JournalPage /></ProtectedRoute>} />
-          <Route path="/ora"     element={<ProtectedRoute><OraPage /></ProtectedRoute>} />
-          <Route path="/dao"      element={<ProtectedRoute><DAOPage /></ProtectedRoute>} />
-          <Route path="/contribute" element={<ProtectedRoute><ContributePage /></ProtectedRoute>} />
-          <Route path="/services" element={<ProtectedRoute><ServicesPage /></ProtectedRoute>} />
-          <Route path="/profile"  element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
-          <Route path="/ioo"      element={<ProtectedRoute><IOOPage /></ProtectedRoute>} />
+
+          {/* Connectome AIOS app routes */}
+          <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
+          <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
+          <Route path="/app/dao" element={<ShellRoute activeApp="dao"><DAOPage /></ShellRoute>} />
+          <Route path="/app/contribute" element={<ShellRoute activeApp="contribute"><ContributePage /></ShellRoute>} />
+          <Route path="/app/profile" element={<ShellRoute activeApp="profile"><ProfilePage /></ShellRoute>} />
+          <Route path="/app/journal" element={<ShellRoute activeApp="journal"><JournalPage /></ShellRoute>} />
+          <Route path="/app/services" element={<ShellRoute activeApp="services"><ServicesPage /></ShellRoute>} />
+          <Route path="/app/ioo" element={<ShellRoute activeApp="ioo"><IOOPage /></ShellRoute>} />
+          <Route path="/app/ivive" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
+
+          {/* Backward-compatible redirects */}
+          <Route path="/home" element={<Navigate to="/" replace />} />
+          <Route path="/feed" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/discover" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/goals" element={<Navigate to="/app/goals" replace />} />
+          <Route path="/journal" element={<Navigate to="/app/journal" replace />} />
+          <Route path="/ora" element={<Navigate to="/" replace />} />
+          <Route path="/dao" element={<Navigate to="/app/dao" replace />} />
+          <Route path="/contribute" element={<Navigate to="/app/contribute" replace />} />
+          <Route path="/services" element={<Navigate to="/app/services" replace />} />
+          <Route path="/profile" element={<Navigate to="/app/profile" replace />} />
+          <Route path="/ioo" element={<Navigate to="/app/ioo" replace />} />
+
           {/* WebSpawn surfaces — auth-gated but accessible via direct link */}
-          <Route path="/surfaces/:surfaceId" element={<SurfacePage />} />
+          <Route path="/surfaces/:surfaceId" element={<ShellRoute activeApp="services"><SurfacePage /></ShellRoute>} />
         </Routes>
       </Suspense>
     </div>

--- a/src/pages/ConnectomeHome.tsx
+++ b/src/pages/ConnectomeHome.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { CONNECTOME_APPS } from '../shell/AppLauncher';
+
+const highlights = [
+  { label: 'Next IOO node', title: 'Clarify your next 24-hour move', meta: '+25 XP when completed' },
+  { label: 'Pending challenge', title: 'Aventi discovery streak is waiting', meta: '12 minutes to start' },
+  { label: 'Signal from the network', title: '2 friends logged new intentions', meta: 'Reflect or join' },
+];
+
+const recent = [
+  'Ora mapped a fresh goal thread from your last session.',
+  'DAO contribution queue refreshed with new CP opportunities.',
+  'Your discovery feed has 4 new adventures tuned to your current path.',
+];
+
+function greetingName(profile: any) {
+  const raw = profile?.display_name || profile?.name || profile?.email?.split('@')[0] || 'Avi';
+  return String(raw).split(' ')[0];
+}
+
+function dayPart() {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'morning';
+  if (hour < 18) return 'afternoon';
+  return 'evening';
+}
+
+export default function ConnectomeHome() {
+  const { profile } = useAuth();
+  const navigate = useNavigate();
+
+  return (
+    <div className="connectome-home">
+      <section className="connectome-home__hero">
+        <div className="connectome-home__signal">
+          <span className="ora-orb" /> Ora is online
+        </div>
+        <h1>Good {dayPart()}, {greetingName(profile)}.</h1>
+        <p>Here's what's calling for your attention today.</p>
+      </section>
+
+      <section className="connectome-home__highlights" aria-label="Ora highlights">
+        {highlights.map((item) => (
+          <article key={item.label} className="connectome-home__highlight">
+            <span>{item.label}</span>
+            <h3>{item.title}</h3>
+            <p>{item.meta}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="connectome-home__apps" aria-label="Apps">
+        {CONNECTOME_APPS.filter((app) => !app.soon).slice(0, 5).map((app) => (
+          <button key={app.name} type="button" onClick={() => navigate(app.path)}>
+            <span>{app.icon}</span>
+            <strong>{app.name}</strong>
+          </button>
+        ))}
+      </section>
+
+      <section className="connectome-home__activity">
+        <div>
+          <span>Recent activity</span>
+          <h2>Light signals from the OS</h2>
+        </div>
+        {recent.map((entry) => <p key={entry}>{entry}</p>)}
+      </section>
+    </div>
+  );
+}

--- a/src/shell/AppLauncher.tsx
+++ b/src/shell/AppLauncher.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const CONNECTOME_APPS = [
+  { path: '/app/ido', icon: '🚀', name: 'iDo', description: 'Adventure, discovery, and what to do next.' },
+  { path: '/app/goals', icon: '🎯', name: 'Goals', description: 'Your IOO path, broken into living quests.' },
+  { path: '/app/dao', icon: '🏛️', name: 'DAO', description: 'Contribute, coordinate, and earn CP.' },
+  { path: '/app/journal', icon: '📓', name: 'Journal', description: 'Reflection, memory, and pattern discovery.' },
+  { path: '/app/profile', icon: '👤', name: 'Profile', description: 'Identity, stats, streaks, and sovereignty.' },
+  { path: '/app/ivive', icon: '🌱', name: 'iVive', description: 'Biometrics and vitality signals. Coming soon.', soon: true },
+];
+
+interface AppLauncherProps {
+  onLaunch?: () => void;
+}
+
+export default function AppLauncher({ onLaunch }: AppLauncherProps) {
+  const navigate = useNavigate();
+
+  const launch = (path: string, soon?: boolean) => {
+    if (soon) return;
+    navigate(path);
+    onLaunch?.();
+  };
+
+  return (
+    <section className="app-launcher" aria-label="Connectome app launcher">
+      <div className="app-launcher__intro">
+        <span>Applications</span>
+        <h2>Choose where Connectome should focus.</h2>
+      </div>
+      <div className="app-launcher__grid">
+        {CONNECTOME_APPS.map((app) => (
+          <button
+            key={app.name}
+            type="button"
+            className="app-launcher__card"
+            onClick={() => launch(app.path, app.soon)}
+            aria-disabled={app.soon}
+          >
+            <span className="app-launcher__icon">{app.icon}</span>
+            <span className="app-launcher__name">{app.name}</span>
+            <span className="app-launcher__description">{app.description}</span>
+            {app.soon && <span className="app-launcher__soon">More coming</span>}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import AppLauncher from './AppLauncher';
+import OraOverlay from './OraOverlay';
+
+interface ConnectomeShellProps {
+  children: React.ReactNode;
+  activeApp?: 'home' | 'ido' | 'goals' | 'dao' | 'contribute' | 'journal' | 'profile' | 'services' | 'ioo';
+}
+
+const appLabels: Record<string, string> = {
+  ido: 'iDo',
+  goals: 'Goals',
+  dao: 'DAO',
+  contribute: 'Contribute',
+  journal: 'Journal',
+  profile: 'Profile',
+  services: 'Services',
+  ioo: 'IOO Map',
+};
+
+const dockItems = [
+  { id: 'ora', label: 'Ora', icon: '◈' },
+  { id: 'ido', label: 'iDo', icon: '🚀', path: '/app/ido' },
+  { id: 'dao', label: 'DAO', icon: '🏛️', path: '/app/dao' },
+  { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },
+  { id: 'apps', label: 'Apps', icon: '+' },
+];
+
+function initials(profile: any) {
+  return String(profile?.display_name || profile?.email || 'U')[0].toUpperCase();
+}
+
+function xpLevel(profile: any) {
+  const xp = Number(profile?.xp ?? profile?.profile?.xp ?? 420);
+  return Math.max(1, Math.floor(xp / 250) + 1);
+}
+
+export default function ConnectomeShell({ children, activeApp = 'home' }: ConnectomeShellProps) {
+  const { profile, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [oraOpen, setOraOpen] = useState(false);
+  const [launcherOpen, setLauncherOpen] = useState(false);
+
+  const openApps = () => setLauncherOpen(true);
+  const closeApps = () => setLauncherOpen(false);
+
+  const handleDock = (item: typeof dockItems[number]) => {
+    if (item.id === 'ora') {
+      setOraOpen(true);
+      return;
+    }
+    if (item.id === 'apps') {
+      openApps();
+      return;
+    }
+    if (item.path) navigate(item.path);
+  };
+
+  return (
+    <div className="connectome-shell">
+      <div className="connectome-stars" aria-hidden="true" />
+      <header className="connectome-topbar">
+        <button className="connectome-brand" type="button" onClick={() => navigate('/')} aria-label="Connectome home">
+          <span className="connectome-brand__glyph">◌</span>
+          <span>
+            <strong>Connectome</strong>
+            <small>AI OS</small>
+          </span>
+        </button>
+
+        <button className="connectome-ora-indicator" type="button" onClick={() => setOraOpen(true)}>
+          <span className="ora-orb" />
+          <span>Ora ambient</span>
+        </button>
+
+        <div className="connectome-status">
+          <span className="connectome-xp">LVL {xpLevel(profile)}</span>
+          <button type="button" className="connectome-bell" aria-label="Notifications">🔔</button>
+          <button type="button" className="connectome-avatar" onClick={() => navigate('/app/profile')} title="Profile">
+            {initials(profile)}
+          </button>
+        </div>
+      </header>
+
+      <main className={`connectome-main connectome-main--${activeApp}`}>
+        {activeApp !== 'home' && appLabels[activeApp] && (
+          <div className="connectome-app-titlebar">
+            <span>{appLabels[activeApp]}</span>
+            <small>{activeApp === 'ido' ? 'Adventure & discovery inside Connectome' : 'Running inside Connectome'}</small>
+          </div>
+        )}
+        {children}
+      </main>
+
+      <nav className="connectome-dock" aria-label="Connectome dock">
+        {dockItems.map((item) => {
+          const active = item.id === activeApp || (item.path && location.pathname === item.path);
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={`connectome-dock__item ${active ? 'connectome-dock__item--active' : ''} ${item.id === 'ora' ? 'connectome-dock__item--ora' : ''}`}
+              onClick={() => handleDock(item)}
+              aria-label={item.label}
+            >
+              <span>{item.icon}</span>
+              <small>{item.label}</small>
+            </button>
+          );
+        })}
+      </nav>
+
+      {launcherOpen && (
+        <div className="connectome-launcher-sheet" onClick={closeApps}>
+          <div className="connectome-launcher-sheet__panel" onClick={(event) => event.stopPropagation()}>
+            <button type="button" className="connectome-launcher-sheet__close" onClick={closeApps}>×</button>
+            <AppLauncher onLaunch={closeApps} />
+          </div>
+        </div>
+      )}
+
+      <button className="connectome-signout" type="button" onClick={() => { logout(); navigate('/'); }}>Sign out</button>
+      <OraOverlay open={oraOpen} onClose={() => setOraOpen(false)} />
+    </div>
+  );
+}

--- a/src/shell/OraOverlay.tsx
+++ b/src/shell/OraOverlay.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { OraClient } from '../lib/OraClient';
+
+type Message = { id: string; role: 'user' | 'ora'; content: string };
+
+interface OraOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const quickActions = ['Show my path', 'What should I do today?', 'How am I doing?'];
+
+export default function OraOverlay({ open, onClose }: OraOverlayProps) {
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: 'opening',
+      role: 'ora',
+      content: "I'm here. Ask me anything, or choose a signal below and I'll orient the whole OS around it.",
+    },
+  ]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) setTimeout(() => endRef.current?.scrollIntoView({ behavior: 'smooth' }), 80);
+  }, [open, messages, loading]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const sendMessage = async (override?: string) => {
+    const text = (override ?? input).trim();
+    if (!text || loading) return;
+    setInput('');
+    setMessages((prev) => [...prev, { id: `${Date.now()}-user`, role: 'user', content: text }]);
+    setLoading(true);
+
+    try {
+      const history = messages.slice(-10).map((m) => ({
+        role: m.role === 'ora' ? 'assistant' : 'user',
+        content: m.content,
+      }));
+      const res = await OraClient.chat(text, history);
+      setMessages((prev) => [...prev, { id: `${Date.now()}-ora`, role: 'ora', content: res.reply }]);
+    } catch {
+      setMessages((prev) => [...prev, {
+        id: `${Date.now()}-fallback`,
+        role: 'ora',
+        content: "I couldn't reach my deeper systems just now, but I'm still here. Try again in a moment.",
+      }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePointerDown = (event: React.PointerEvent) => {
+    const startY = event.clientY;
+    const onPointerUp = (upEvent: PointerEvent) => {
+      if (upEvent.clientY - startY > 90) onClose();
+      window.removeEventListener('pointerup', onPointerUp);
+    };
+    window.addEventListener('pointerup', onPointerUp);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="ora-overlay" role="dialog" aria-modal="true" aria-label="Ora OS overlay">
+      <div className="ora-overlay__scrim" onClick={onClose} />
+      <div className="ora-overlay__panel" ref={panelRef} onPointerDown={handlePointerDown}>
+        <header className="ora-overlay__header">
+          <div className="ora-overlay__handle" />
+          <div className="ora-overlay__identity">
+            <span className="ora-orb ora-orb--large" />
+            <div>
+              <div className="ora-overlay__eyebrow">OS-level intelligence</div>
+              <h2>Ora</h2>
+            </div>
+          </div>
+          <button className="ora-overlay__close" type="button" onClick={onClose} aria-label="Close Ora">×</button>
+        </header>
+
+        <div className="ora-overlay__messages">
+          {messages.map((message) => (
+            <div key={message.id} className={`ora-overlay__message ora-overlay__message--${message.role}`}>
+              {message.role === 'ora' && <span className="ora-orb ora-orb--small" />}
+              <div>{message.content}</div>
+            </div>
+          ))}
+          {loading && (
+            <div className="ora-overlay__message ora-overlay__message--ora">
+              <span className="ora-orb ora-orb--small" />
+              <div className="ora-overlay__typing"><span /><span /><span /></div>
+            </div>
+          )}
+          <div ref={endRef} />
+        </div>
+
+        <div className="ora-overlay__quick-actions">
+          {quickActions.map((action) => (
+            <button key={action} type="button" onClick={() => sendMessage(action)}>{action}</button>
+          ))}
+        </div>
+
+        <form className="ora-overlay__composer" onSubmit={(event) => { event.preventDefault(); sendMessage(); }}>
+          <input
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="Ask Ora to navigate, reflect, plan, or decide…"
+            autoFocus
+          />
+          <button type="submit" disabled={!input.trim() || loading}>Send</button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary\n- Replace the authenticated mobile-app nav paradigm with a Connectome AI OS shell: top bar, ambient Ora indicator, bottom dock, and app title chrome.\n- Add OS-level Ora overlay and app launcher with iDo as the first named app inside Connectome.\n- Move authenticated routes under /app/* with backward-compatible redirects from legacy paths.\n- Add a new Connectome home desktop with Ora highlights, app shortcuts, and recent activity.\n- Shift global styling toward a dark, spatial, ambient AIOS aesthetic.\n\n## Test\n- npm run build