### PR TITLE
Move app launcher to hamburger toggle

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -411,19 +411,62 @@ body {
   border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 
+.connectome-topbar--launcher-open {
+  z-index: 220;
+}
+
 .connectome-brand,
 .connectome-ora-indicator,
+.connectome-launcher-toggle,
 .connectome-status button,
 .connectome-dock__item {
   background: transparent;
   color: inherit;
 }
 
+.connectome-launcher-toggle {
+  position: relative;
+  justify-self: start;
+  width: 28px;
+  height: 28px;
+  min-height: 28px;
+  padding: 0;
+  border: 0;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: #fff;
+}
+
+.connectome-launcher-toggle__line {
+  width: 20px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transform-origin: center;
+  transition: transform 200ms ease, opacity 160ms ease, width 200ms ease;
+}
+
+.connectome-launcher-toggle--open .connectome-launcher-toggle__line:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.connectome-launcher-toggle--open .connectome-launcher-toggle__line:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0.35);
+}
+
+.connectome-launcher-toggle--open .connectome-launcher-toggle__line:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
 .connectome-brand {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  justify-self: start;
+  justify-self: center;
   min-height: 44px;
   text-align: left;
 }
@@ -546,10 +589,10 @@ body {
   bottom: max(14px, env(safe-area-inset-bottom));
   z-index: 95;
   transform: translateX(-50%);
-  width: min(520px, calc(100vw - 24px));
+  width: min(430px, calc(100vw - 24px));
   height: 72px;
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
   padding: 8px;
   border-radius: 28px;
@@ -712,22 +755,34 @@ body {
 
 .connectome-launcher-sheet {
   display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  padding: 16px;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: calc(var(--top-header-height) + 12px) 16px 16px;
   background: rgba(0,0,0,0.52);
   backdrop-filter: blur(12px);
+  animation: connectomeLauncherFade 200ms ease both;
 }
 
 .connectome-launcher-sheet__panel {
   position: relative;
-  width: min(880px, 100%);
-  max-height: min(82vh, 760px);
+  width: min(440px, calc(100vw - 32px));
+  max-height: 100%;
   overflow: auto;
   border-radius: 34px;
   border: 1px solid rgba(255,255,255,0.12);
   background: rgba(9, 10, 22, 0.92);
   box-shadow: 0 24px 90px rgba(0,0,0,0.58);
+  animation: connectomeLauncherSlideIn 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes connectomeLauncherFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes connectomeLauncherSlideIn {
+  from { opacity: 0; transform: translateX(-24px); }
+  to { opacity: 1; transform: translateX(0); }
 }
 
 .connectome-launcher-sheet__close,
@@ -748,6 +803,7 @@ body {
 .app-launcher { padding: clamp(24px, 5vw, 42px); }
 .app-launcher__intro h2 { margin-top: 8px; font-size: clamp(28px, 5vw, 46px); line-height: 1; letter-spacing: -0.07em; }
 .app-launcher__grid { margin-top: 26px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.connectome-launcher-sheet__panel .app-launcher__grid { grid-template-columns: 1fr; }
 .app-launcher__card { min-height: 188px; padding: 22px; text-align: left; color: #f8f8fc; display: flex; flex-direction: column; align-items: flex-start; }
 .app-launcher__card:hover { transform: translateY(-3px); border-color: rgba(0,212,170,0.28); }
 .app-launcher__icon { font-size: 34px; }

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -25,12 +25,7 @@ const dockItems = [
   { id: 'ido', label: 'iDo', icon: '🚀', path: '/app/ido' },
   { id: 'dao', label: 'DAO', icon: '🏛️', path: '/app/dao' },
   { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },
-  { id: 'apps', label: 'Apps', icon: '+' },
 ];
-
-function initials(profile: any) {
-  return String(profile?.display_name || profile?.email || 'U')[0].toUpperCase();
-}
 
 function xpLevel(profile: any) {
   const xp = Number(profile?.xp ?? profile?.profile?.xp ?? 420);
@@ -44,16 +39,12 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
   const [oraOpen, setOraOpen] = useState(false);
   const [launcherOpen, setLauncherOpen] = useState(false);
 
-  const openApps = () => setLauncherOpen(true);
   const closeApps = () => setLauncherOpen(false);
+  const toggleApps = () => setLauncherOpen((open) => !open);
 
   const handleDock = (item: typeof dockItems[number]) => {
     if (item.id === 'ora') {
       setOraOpen(true);
-      return;
-    }
-    if (item.id === 'apps') {
-      openApps();
       return;
     }
     if (item.path) navigate(item.path);
@@ -62,7 +53,20 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
   return (
     <div className="connectome-shell">
       <div className="connectome-stars" aria-hidden="true" />
-      <header className="connectome-topbar">
+      <header className={`connectome-topbar ${launcherOpen ? 'connectome-topbar--launcher-open' : ''}`}>
+        <button
+          className={`connectome-launcher-toggle ${launcherOpen ? 'connectome-launcher-toggle--open' : ''}`}
+          type="button"
+          onClick={toggleApps}
+          aria-label={launcherOpen ? 'Close app launcher' : 'Open app launcher'}
+          aria-expanded={launcherOpen}
+          aria-controls="connectome-app-launcher"
+        >
+          <span className="connectome-launcher-toggle__line" />
+          <span className="connectome-launcher-toggle__line" />
+          <span className="connectome-launcher-toggle__line" />
+        </button>
+
         <button className="connectome-brand" type="button" onClick={() => navigate('/')} aria-label="Connectome home">
           <span className="connectome-brand__glyph">◌</span>
           <span>
@@ -71,17 +75,9 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
           </span>
         </button>
 
-        <button className="connectome-ora-indicator" type="button" onClick={() => setOraOpen(true)}>
-          <span className="ora-orb" />
-          <span>Ora ambient</span>
-        </button>
-
         <div className="connectome-status">
           <span className="connectome-xp">LVL {xpLevel(profile)}</span>
           <button type="button" className="connectome-bell" aria-label="Notifications">🔔</button>
-          <button type="button" className="connectome-avatar" onClick={() => navigate('/app/profile')} title="Profile">
-            {initials(profile)}
-          </button>
         </div>
       </header>
 
@@ -115,8 +111,11 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
 
       {launcherOpen && (
         <div className="connectome-launcher-sheet" onClick={closeApps}>
-          <div className="connectome-launcher-sheet__panel" onClick={(event) => event.stopPropagation()}>
-            <button type="button" className="connectome-launcher-sheet__close" onClick={closeApps}>×</button>
+          <div
+            id="connectome-app-launcher"
+            className="connectome-launcher-sheet__panel"
+            onClick={(event) => event.stopPropagation()}
+          >
             <AppLauncher onLaunch={closeApps} />
           </div>
         </div>


### PR DESCRIPTION
## Summary\n- move the app launcher trigger from the bottom dock to a top-left hamburger/X toggle\n- remove the Apps dock item and rebalance the dock to four items\n- make the launcher appear as a left-side overlay that dismisses via outside tap or the top-left X\n\n## Validation\n- npm run build