### PR TITLE
docs: add developer contribution pathway

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to Connectome Web
+
+Connectome Web is the interface for Ora, iDo, and the Ascension Technologies contribution economy. Contributions should make the AI OS clearer, calmer, more useful, or easier to build on.
+
+## Local setup
+
+```bash
+git clone https://github.com/AvielCarlos/connectome-web.git
+cd connectome-web
+npm install
+npm run dev
+```
+
+Before opening a PR, run:
+
+```bash
+npm run build
+```
+
+## How to pick work
+
+1. Browse open issues.
+2. Prefer issues labelled `good first issue`, `frontend`, `design`, `agent-dev`, or `growth`.
+3. Comment with your intended approach if the work affects UX architecture or agent behaviour.
+4. Keep PRs focused and reviewable.
+
+## Contribution categories
+
+- **Frontend/product** — React surfaces, routes, state, user flows, responsive polish.
+- **Design systems** — shared components, layout primitives, visual consistency, accessibility.
+- **Agent UX** — Ora overlays, contextual actions, IOO progress states, agent handoffs.
+- **Growth engineering** — onboarding analytics, contribution funnel, referral loops, activation metrics.
+- **DAO/contribution UX** — CP visibility, leaderboards, steward pathways, contribution submission.
+- **Docs/devex** — setup guides, architecture notes, examples, issue quality.
+
+## CP rewards
+
+Contribution Points recognise shipped work and help identify trusted builders in the ecosystem.
+
+| Work type | Typical CP |
+| --- | ---: |
+| Docs polish, small UI bug, copy fix | 25–75 |
+| Good first issue / contained component | 75–200 |
+| Product feature, route, agent UX integration | 200–600 |
+| Major design system, architecture, growth loop | 600–1,500+ |
+
+CP is awarded after review based on impact, quality, maintainability, and mission alignment. Include your expected CP category in the PR description.
+
+## Pull request checklist
+
+- [ ] The PR has a clear title and summary.
+- [ ] The change is scoped to one user/developer problem.
+- [ ] `npm run build` passes, or the blocker is stated.
+- [ ] UX changes include screenshots or a short screen recording when practical.
+- [ ] New routes/components are named clearly and are reusable where appropriate.
+- [ ] The PR links the related issue and mentions expected CP category.
+
+## Product principles
+
+- Make powerful AI feel calm and understandable.
+- Prefer composable components over one-off screens.
+- Show users what Ora is doing and why.
+- Keep contribution and CP pathways visible without turning the product into a casino.
+- Build surfaces that a real person would trust with their daily life.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Connectome Web — iDo/Ora AI OS Interface
+
+Connectome Web is the user-facing surface for an AI OS for human flourishing. It is where Ora, iDo, the Connectome nervous system, and the Ascension Technologies DAO become understandable and usable for real people.
+
+The app combines daily action, goals, routines, discovery, contribution, DAO visibility, and agentic assistance into a WeChat-like life OS experience.
+
+## Why builders should care
+
+This is a rare chance to shape the interface layer for an agentic AI ecosystem:
+
+- **Frontend/design engineers** can turn complex AI systems into calm, practical product surfaces.
+- **Agent developers** can expose Ora capabilities through contextual quick actions, overlays, and workflows.
+- **Growth engineers** can improve onboarding, contribution loops, analytics, referrals, and activation.
+- **Product engineers** can connect mission, CP rewards, DAO participation, and daily utility in one coherent experience.
+
+Contributors earn Contribution Points (CP), leaderboard recognition, and a path toward founding steward status in the Ascension Technologies ecosystem.
+
+## Architecture overview
+
+```text
+Connectome Web
+├── React + Vite + TypeScript app
+├── ConnectomeShell / AppLauncher      AI OS shell
+├── OraOverlay                         contextual assistant layer
+├── Pages                              goals, routines, feed, DAO, IOO, profile, contribution
+├── Components                         reusable product surfaces
+└── OraClient                          API client for Connectome backend
+```
+
+Ecosystem map:
+
+- **Ora** — the AI brain and agent layer.
+- **Connectome** — the AI OS / nervous system.
+- **iDo** — the daily app experience.
+- **Ascension Technologies** — DAO, CP, governance, and contributor ownership layer.
+
+## Contribute and earn CP
+
+Contribution Points recognise shipped work and help identify trusted builders.
+
+| Contribution | CP range |
+| --- | ---: |
+| UI polish, docs, small bug | 25–75 CP |
+| Good first issue / contained component | 75–200 CP |
+| Product feature or agent UX integration | 200–600 CP |
+| Major UX system, design architecture, growth engine | 600–1,500+ CP |
+
+CP can support reputation, leaderboard placement, steward invitations, governance influence, and future upside as the DAO matures.
+
+## Good first areas
+
+- Build a shared design component kit: `PageHero`, `SectionCard`, `PrimaryCTA`.
+- Add contextual Ora quick actions per page.
+- Split Profile vs Admin/System routes for clearer information architecture.
+- Improve IOO execution UX and agent progress states.
+- Add developer onboarding analytics and contribution funnel tracking.
+- Improve responsive polish for iDo-style daily surfaces.
+
+## Local setup
+
+```bash
+git clone https://github.com/AvielCarlos/connectome-web.git
+cd connectome-web
+npm install
+npm run dev
+```
+
+Useful checks:
+
+```bash
+npm run build
+```
+
+## Start contributing
+
+1. Read [`CONTRIBUTING.md`](CONTRIBUTING.md).
+2. Read [`docs/DEVELOPER_MISSION.md`](docs/DEVELOPER_MISSION.md).
+3. Pick an issue labelled `good first issue`, `frontend`, `agent-dev`, `design`, or `growth`.
+4. Comment with your intended approach.
+5. Open a focused PR and mention the CP category you believe applies.
+
+The bar is simple: make meaningful AI infrastructure feel usable, trustworthy, and alive.

--- a/docs/DEVELOPER_MISSION.md
+++ b/docs/DEVELOPER_MISSION.md
@@ -1,0 +1,55 @@
+# Developer Mission — Design the Interface for an AI OS
+
+Connectome Web is the human surface of the Ascension Technologies ecosystem. It turns the Ora brain and Connectome nervous system into a daily product people can use to act, reflect, discover, contribute, and coordinate.
+
+The ecosystem has four layers:
+
+- **Ora** — the AI brain: agents that understand goals, context, constraints, opportunities, and feedback.
+- **Connectome** — the nervous system: APIs, graph intelligence, memory, execution protocol, and integrations.
+- **iDo** — the daily surface: a WeChat-like app for action, discovery, routines, services, and community.
+- **Ascension Technologies** — the DAO/governance layer: CP, recognition, stewardship, and eventual economic coordination.
+
+## What builders can create here
+
+High-leverage frontend work includes:
+
+- Contextual Ora quick actions that make each page feel agent-aware.
+- Shared design primitives that make the app faster to extend.
+- IOO execution views that show agent progress, options, and decisions clearly.
+- Contribution and CP surfaces that help developers understand the path from shipped work to recognition.
+- Growth instrumentation that reveals where builders and users get stuck.
+- Mobile-first iDo interactions that feel simple enough for daily use.
+
+## Why this matters
+
+Agentic AI will only matter if people can trust it, understand it, and integrate it into daily life. The interface is not decoration — it is the trust layer.
+
+Good Connectome Web work helps users:
+
+- understand what Ora can do,
+- choose meaningful next actions,
+- see progress without cognitive overload,
+- contribute to the ecosystem,
+- and feel that AI is serving their flourishing rather than extracting attention.
+
+## How contribution becomes status
+
+Contributors earn CP for shipped work. CP is a public signal of trust and impact. Over time it can support:
+
+- leaderboard recognition,
+- founding steward invitations,
+- governance influence,
+- access to higher-leverage product work,
+- and potential economic upside as the DAO matures.
+
+## What good work looks like
+
+Good Connectome Web contributions are:
+
+- **Clear** — users know what is happening and what to do next.
+- **Composable** — future pages and agents can reuse the pattern.
+- **Accessible** — the product works across devices and ability levels.
+- **Mission-aligned** — it supports human flourishing, not addictive engagement.
+- **Credible** — ambitious, but grounded in shippable product quality.
+
+Start with a focused issue, ship a clean PR, and help make the AI OS tangible.


### PR DESCRIPTION
## Summary\n- add a mission-aligned README for frontend contributors\n- add CONTRIBUTING with setup, CP ranges, and PR expectations\n- add a developer mission doc for AI OS/interface builders\n\n## Validation\n- Docs-only change; no build required.\n