### PR TITLE
Add CP explainer to feedback modal

### DIFF
--- a/src/components/CPExplainerModal.tsx
+++ b/src/components/CPExplainerModal.tsx
@@ -1,0 +1,36 @@
+type CPExplainerModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function CPExplainerModal({ open, onClose }: CPExplainerModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="cp-explainer-backdrop" data-feedback-widget="true" onClick={onClose}>
+      <section
+        className="cp-explainer-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cp-explainer-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button type="button" className="cp-explainer-close" aria-label="Close CP explainer" onClick={onClose}>
+          ×
+        </button>
+        <div className="cp-explainer-kicker">Contribution Points</div>
+        <h2 id="cp-explainer-title">What is CP?</h2>
+        <p>
+          CP is Ora’s contribution score — a simple way to recognize people who help improve the product,
+          community, and mission.
+        </p>
+        <ul>
+          <li><strong>Feedback earns CP</strong> because noticing what’s broken, confusing, or useful helps Ora learn faster.</li>
+          <li><strong>Bigger contributions earn more</strong>: code, design, docs, research, community support, and useful ideas all count.</li>
+          <li><strong>CP builds reputation</strong> in the Ascension DAO and may unlock governance, rewards, and future participation as the system matures.</li>
+        </ul>
+        <div className="cp-explainer-note">Quality matters more than volume. Real value earns real signal.</div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/GlobalFeedbackButton.tsx
+++ b/src/components/GlobalFeedbackButton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import html2canvas from 'html2canvas';
 import { OraClient, GlobalFeedbackPayload } from '../lib/OraClient';
+import CPExplainerModal from './CPExplainerModal';
 import { useToast } from './Toast';
 
 const CATEGORIES: GlobalFeedbackPayload['category'][] = ['Bug', 'Confusing', 'Idea', 'Design', 'Praise', 'Other'];
@@ -8,6 +9,7 @@ const CATEGORIES: GlobalFeedbackPayload['category'][] = ['Bug', 'Confusing', 'Id
 export default function GlobalFeedbackButton() {
   const { show } = useToast();
   const [open, setOpen] = useState(false);
+  const [cpExplainerOpen, setCpExplainerOpen] = useState(false);
   const [category, setCategory] = useState<GlobalFeedbackPayload['category']>('Idea');
   const [message, setMessage] = useState('');
   const [includeScreenshot, setIncludeScreenshot] = useState(true);
@@ -106,7 +108,11 @@ export default function GlobalFeedbackButton() {
             <div className="global-feedback-modal__header">
               <div>
                 <h2 id="global-feedback-title">Help improve Ora</h2>
-                <p>Send what you notice here and earn contribution points.</p>
+                <p className="global-feedback-reward">
+                  <span>Earn +10 CP</span>
+                  <span aria-hidden="true">·</span>
+                  <button type="button" onClick={() => setCpExplainerOpen(true)}>What is CP?</button>
+                </p>
               </div>
               <button type="button" aria-label="Close feedback" onClick={resetAndClose} disabled={submitting}>×</button>
             </div>
@@ -148,11 +154,13 @@ export default function GlobalFeedbackButton() {
             {error && <div className="global-feedback-error" role="alert">{error}</div>}
 
             <button type="button" className="global-feedback-submit" onClick={handleSubmit} disabled={submitting}>
-              {submitting ? 'Sending…' : 'Send feedback + earn CP'}
+              {submitting ? 'Sending…' : 'Send feedback + earn 10 CP'}
             </button>
           </section>
         </div>
       )}
+
+      <CPExplainerModal open={cpExplainerOpen} onClose={() => setCpExplainerOpen(false)} />
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1085,7 +1085,14 @@ body {
 .global-feedback-modal__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
 .global-feedback-modal__header h2 { margin: 0; font-size: 22px; letter-spacing: -0.02em; }
 .global-feedback-modal__header p { margin: 5px 0 0; color: rgba(248,248,252,0.58); font-size: 13px; }
-.global-feedback-modal__header button {
+.global-feedback-reward { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.global-feedback-reward span:first-child { color: #f4c26b; font-weight: 900; }
+.global-feedback-reward button {
+  min-height: 0; padding: 0; border: none; background: transparent; color: #7dd3fc;
+  font-size: 13px; font-weight: 900; text-decoration: underline; text-underline-offset: 3px; cursor: pointer;
+}
+.global-feedback-reward button:hover { color: #bae6fd; }
+.global-feedback-modal__header > button {
   width: 34px; height: 34px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.1);
   background: rgba(255,255,255,0.06); color: rgba(248,248,252,0.82); font-size: 22px; cursor: pointer;
 }
@@ -1110,6 +1117,31 @@ body {
   box-shadow: 0 14px 34px rgba(37,99,235,0.26);
 }
 .global-feedback-submit:disabled { opacity: 0.62; cursor: wait; }
+
+.cp-explainer-backdrop {
+  position: fixed; inset: 0; z-index: 2300; background: rgba(3, 6, 20, 0.78);
+  backdrop-filter: blur(14px); display: flex; align-items: center; justify-content: center; padding: 18px;
+}
+.cp-explainer-modal {
+  position: relative; width: min(500px, 100%); border-radius: 24px; border: 1px solid rgba(255,255,255,0.14);
+  background: linear-gradient(180deg, rgba(24,27,48,0.98), rgba(8,10,20,0.99));
+  box-shadow: 0 24px 90px rgba(0,0,0,0.58); padding: 26px; color: #f8f8fc;
+}
+.cp-explainer-close {
+  position: absolute; top: 14px; right: 14px; width: 34px; height: 34px; min-height: 34px; border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.06); color: rgba(248,248,252,0.82);
+  font-size: 22px; cursor: pointer;
+}
+.cp-explainer-kicker { color: #f4c26b; font-size: 12px; font-weight: 950; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; }
+.cp-explainer-modal h2 { margin: 0 42px 10px 0; font-size: 28px; letter-spacing: -0.04em; }
+.cp-explainer-modal p { margin: 0; color: rgba(248,248,252,0.68); line-height: 1.6; }
+.cp-explainer-modal ul { margin: 18px 0 0; padding-left: 20px; color: rgba(248,248,252,0.74); line-height: 1.65; }
+.cp-explainer-modal li + li { margin-top: 10px; }
+.cp-explainer-modal strong { color: #f8f8fc; }
+.cp-explainer-note {
+  margin-top: 18px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(244,194,107,0.22);
+  background: rgba(244,194,107,0.08); color: rgba(248,248,252,0.78); font-size: 13px; font-weight: 800;
+}
 
 @media (min-width: 768px) {
   .global-feedback-fab { bottom: 28px; right: 28px; }


### PR DESCRIPTION
## Summary
- add a reusable CP explainer modal
- place the required "Earn +10 CP · What is CP?" link in the global feedback modal
- clarify the feedback submit CTA as +10 CP

## Test
- npm run build