### PR TITLE
Make XP soft and invisible in UI

### DIFF
--- a/src/components/MiniAppSurface.tsx
+++ b/src/components/MiniAppSurface.tsx
@@ -984,11 +984,11 @@ function SkillTree({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: string
   const cfg = spec.config || {}
   type NodeStatus = 'locked' | 'in_progress' | 'unlocked'
   const defaultNodes: Array<{ id: string; label: string; status: NodeStatus; xp?: number }> = [
-    { id: '1', label: 'Foundations', status: 'unlocked', xp: 100 },
-    { id: '2', label: 'Core Skills', status: 'unlocked', xp: 150 },
-    { id: '3', label: 'Intermediate', status: 'in_progress', xp: 200 },
-    { id: '4', label: 'Advanced', status: 'locked', xp: 250 },
-    { id: '5', label: 'Mastery', status: 'locked', xp: 500 },
+    { id: '1', label: 'Foundations', status: 'unlocked' },
+    { id: '2', label: 'Core Skills', status: 'unlocked' },
+    { id: '3', label: 'Intermediate', status: 'in_progress' },
+    { id: '4', label: 'Advanced', status: 'locked' },
+    { id: '5', label: 'Mastery', status: 'locked' },
   ]
   const nodes: Array<{ id: string; label: string; status: NodeStatus; xp?: number }> = cfg.nodes || defaultNodes
 
@@ -1014,9 +1014,6 @@ function SkillTree({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: string
               <div style={{ fontSize: 18, width: 24, textAlign: 'center', flexShrink: 0 }}>{st.icon}</div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontSize: 14, fontWeight: 600, color: st.textColor }}>{node.label}</div>
-                {node.xp != null && (
-                  <div style={{ fontSize: 11, color: 'rgba(248,248,252,0.3)', marginTop: 2 }}>{node.xp} XP</div>
-                )}
               </div>
               {i < nodes.length - 1 && node.status === 'unlocked' && (
                 <div style={{ fontSize: 10, color: 'rgba(248,248,252,0.2)' }}>▼</div>
@@ -1228,7 +1225,6 @@ function Comparison({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: strin
 function Celebration({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: string) => void }) {
   const cfg = spec.config || {}
   const achievement: string = cfg.achievement || spec.title
-  const xp: number = cfg.xp_earned ?? cfg.xp ?? 0
   const emoji: string = cfg.emoji || '🏆'
   const [shared, setShared] = useState(false)
   const confettiColors = ['#00d4aa', '#a855f7', '#f59e0b', '#f43f5e', '#3b82f6']
@@ -1253,15 +1249,6 @@ function Celebration({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: stri
           ))}
         </div>
         <div style={{ fontSize: 22, fontWeight: 800, color: '#f8f8fc', marginBottom: 8 }}>{achievement}</div>
-        {xp > 0 && (
-          <div style={{
-            display: 'inline-flex', alignItems: 'center', gap: 6,
-            background: 'rgba(0,212,170,0.12)', border: '1px solid rgba(0,212,170,0.3)',
-            borderRadius: 20, padding: '6px 16px', fontSize: 14, fontWeight: 700, color: '#00d4aa',
-          }}>
-            ⚡ +{xp} XP earned
-          </div>
-        )}
         {cfg.message && (
           <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.5)', lineHeight: 1.6, marginTop: 14, padding: '0 8px' }}>
             {cfg.message}
@@ -1272,7 +1259,7 @@ function Celebration({ spec, onAction }: { spec: SurfaceSpec; onAction: (a: stri
         style={s.primaryBtn(shared ? '#10b981' : '#00d4aa')}
         onClick={() => {
           setShared(true)
-          if (navigator.share) navigator.share({ title: achievement, text: `I just earned: ${achievement}${xp ? ` (+${xp} XP!)` : ''}` })
+          if (navigator.share) navigator.share({ title: achievement, text: `I just completed: ${achievement}` })
           onAction('complete')
         }}
       >

--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -3,9 +3,9 @@
  *
  * Shows current streak with animated flame.
  * Pulses red when "at risk" (user hasn't checked in today).
- * Triggers XP pop animation on milestone streaks.
+ * Keeps progress signals soft and non-score-like.
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { OraClient } from '../lib/OraClient';
 
 interface StreakData {
@@ -24,22 +24,13 @@ interface StreakData {
   collections_count: number;
 }
 
-interface XpPop {
-  id: number;
-  amount: number;
-  x: number;
-  y: number;
-}
-
 export function StreakBadge({ compact = false }: { compact?: boolean }) {
   const [data, setData] = useState<StreakData | null>(null);
-  const [xpPops, setXpPops] = useState<XpPop[]>([]);
   const [newBadge, setNewBadge] = useState<{ emoji: string; name: string } | null>(null);
-  const xpPopId = useRef(0);
 
   useEffect(() => {
     fetchStatus();
-    // Checkin on mount (awards daily login XP if first session today)
+    // Check in on mount for backend progress/personalization signals.
     doCheckin();
   }, []);
 
@@ -56,10 +47,6 @@ export function StreakBadge({ compact = false }: { compact?: boolean }) {
     try {
       const result = await OraClient.post<any>('/api/gamification/checkin', { reason: 'daily_login' });
 
-      if (result.xp_awarded > 0) {
-        triggerXpPop(result.xp_awarded);
-      }
-
       if (result.new_badges?.length > 0) {
         setNewBadge(result.new_badges[0]);
         setTimeout(() => setNewBadge(null), 3500);
@@ -70,16 +57,6 @@ export function StreakBadge({ compact = false }: { compact?: boolean }) {
     } catch {
       // Non-critical
     }
-  };
-
-  const triggerXpPop = (amount: number) => {
-    const id = ++xpPopId.current;
-    const x = 50 + Math.random() * 20 - 10;
-    const y = 50;
-    setXpPops((prev) => [...prev, { id, amount, x, y }]);
-    setTimeout(() => {
-      setXpPops((prev) => prev.filter((p) => p.id !== id));
-    }, 1300);
   };
 
   if (!data) return null;
@@ -113,26 +90,6 @@ export function StreakBadge({ compact = false }: { compact?: boolean }) {
         </span>
         <span>{streak.current}</span>
 
-        {/* XP pops */}
-        {xpPops.map((pop) => (
-          <div
-            key={pop.id}
-            className="xp-pop"
-            style={{
-              position: 'absolute',
-              top: -10,
-              left: `${pop.x}%`,
-              transform: 'translateX(-50%)',
-              fontSize: 11,
-              fontWeight: 800,
-              color: '#00d4aa',
-              pointerEvents: 'none',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            +{pop.amount} XP
-          </div>
-        ))}
       </div>
     );
   }
@@ -197,19 +154,14 @@ export function StreakBadge({ compact = false }: { compact?: boolean }) {
             </div>
           </div>
 
-          {/* XP pill */}
-          <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
-            <div style={{ fontSize: 18, fontWeight: 900, color: '#00d4aa' }}>{xp.total.toLocaleString()}</div>
-            <div style={{ fontSize: 11, color: 'rgba(248,248,252,0.35)', fontWeight: 600 }}>XP total</div>
-          </div>
         </div>
 
-        {/* XP progress bar */}
+        {/* Soft milestone progress */}
         {xp.next_milestone && (
           <div>
             <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'rgba(248,248,252,0.3)', marginBottom: 6, fontWeight: 600 }}>
-              <span>{xp.total} XP</span>
-              <span>Next: {xp.next_milestone} XP</span>
+              <span>Milestone progress</span>
+              <span>{Math.round(progressPct)}%</span>
             </div>
             <div className="progress-track">
               <div
@@ -250,27 +202,6 @@ export function StreakBadge({ compact = false }: { compact?: boolean }) {
         )}
       </div>
 
-      {/* XP pops */}
-      {xpPops.map((pop) => (
-        <div
-          key={pop.id}
-          className="xp-pop"
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: `${pop.x}%`,
-            transform: 'translateX(-50%)',
-            fontSize: 14,
-            fontWeight: 800,
-            color: '#00d4aa',
-            pointerEvents: 'none',
-            whiteSpace: 'nowrap',
-            zIndex: 100,
-          }}
-        >
-          +{pop.amount} XP
-        </div>
-      ))}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -297,13 +297,6 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 .streak-flame { animation: streakFlame 0.9s ease-in-out infinite; }
 
-@keyframes xpPop {
-  0%   { opacity: 0; transform: translateY(0) scale(0.6); }
-  40%  { opacity: 1; transform: translateY(-20px) scale(1.1); }
-  100% { opacity: 0; transform: translateY(-48px) scale(0.9); }
-}
-.xp-pop { animation: xpPop 1.2s ease-out forwards; }
-
 @keyframes badgeEarn {
   0%   { transform: scale(0) rotate(-15deg); opacity: 0; }
   60%  { transform: scale(1.2) rotate(5deg);  opacity: 1; }
@@ -566,23 +559,12 @@ body {
   gap: 8px;
 }
 
-.connectome-xp,
 .connectome-bell,
 .connectome-avatar {
   min-height: 38px;
   border-radius: 999px;
   border: 1px solid rgba(255,255,255,0.09);
   background: rgba(255,255,255,0.04) !important;
-}
-
-.connectome-xp {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 12px;
-  color: #00d4aa;
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.09em;
 }
 
 .connectome-bell,
@@ -924,7 +906,6 @@ body {
   .connectome-brand small,
   .connectome-context-label,
   .connectome-ora-indicator span:last-child,
-  .connectome-xp,
   .connectome-app-titlebar small,
   .connectome-signout { display: none; }
   .connectome-brand strong { font-size: 14px; }

--- a/src/pages/ConnectomeHome.tsx
+++ b/src/pages/ConnectomeHome.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { CONNECTOME_APPS } from '../shell/AppLauncher';
 
 const highlights = [
-  { label: 'Next IOO node', title: 'Clarify your next 24-hour move', meta: '+25 XP when completed' },
+  { label: 'Next IOO node', title: 'Clarify your next 24-hour move', meta: 'Ready when you are' },
   { label: 'Pending challenge', title: 'Aventi discovery streak is waiting', meta: '12 minutes to start' },
   { label: 'Signal from the network', title: '2 friends logged new intentions', meta: 'Reflect or join' },
 ];

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -2,7 +2,7 @@
  * FeedPage — TikTok-style vertical snap-scroll feed.
  *
  * v2: Full-bleed visual design (Airbnb/TikTok quality), collection save,
- * streak-aware header, XP awards on interaction.
+ * streak-aware header, backend progress signals on interaction.
  */
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -534,7 +534,7 @@ export default function FeedPage() {
         setIsLimited(batch[batch.length - 1].is_limited);
         setDailyLimit(batch[batch.length - 1].daily_limit);
       }
-      // Award card_view XP
+      // Send backend progress signal.
       OraClient['client'].post('/api/gamification/checkin', { reason: 'card_view' }).catch(() => {});
     } catch (e: any) {
       if (e?.response?.status === 402) setIsLimited(true);
@@ -620,9 +620,9 @@ export default function FeedPage() {
         exit_point: 'rate',
         completed: true,
       });
-      // Award XP
+      // Send backend progress signal.
       OraClient['client'].post('/api/gamification/checkin', { reason: 'card_rate', ref_id: screenId }).catch(() => {});
-      showToast(rating >= 4 ? `♥ Loved it (+15 XP)` : `Rated ${rating}★`);
+      showToast(rating >= 4 ? `♥ Loved it` : `Rated ${rating}★`);
       if (rating >= 4) setTimeout(goNext, 700);
     } catch {}
   };
@@ -636,7 +636,7 @@ export default function FeedPage() {
       setSavedIds((prev) => new Set([...prev, collectionPickerCard.screen_spec_id]));
     }
     setCollectionPickerCard(null);
-    showToast(`✦ Saved to ${collectionName} (+20 XP)`);
+    showToast(`✦ Saved to ${collectionName}`);
     // Navigate to next card after short delay
     setTimeout(goNext, 800);
   };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -338,7 +338,7 @@ export default function ProfilePage() {
       {/* ── Profile section ── */}
       {section === 'profile' && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-          {/* ── Streak + XP + Badges ── */}
+          {/* ── Streak + Milestones + Badges ── */}
           <StreakBadge />
 
           {/* ── Account Info ── */}

--- a/src/runtime/ontology.ts
+++ b/src/runtime/ontology.ts
@@ -445,7 +445,7 @@ export const APP_MANIFEST: AppManifestEntry[] = [
     category: 'governance',
     visibleToUser: true,
     permissions: ['dao', 'social', 'notifications'],
-    description: 'Governance, ownership, CP/XP, proposals, voting, and contributor identity.',
+    description: 'Governance, ownership, CP, proposals, voting, and contributor identity.',
     purpose: 'Governs the ecosystem and rewards contribution without becoming the workbench itself.',
   },
   {

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -112,11 +112,6 @@ const dockMenus: Record<string, DockItem[]> = {
   ],
 };
 
-function xpLevel(profile: any) {
-  const xp = Number(profile?.xp ?? profile?.profile?.xp ?? 420);
-  return Math.max(1, Math.floor(xp / 250) + 1);
-}
-
 function initials(profile: any) {
   const raw = profile?.display_name || profile?.name || profile?.email || 'Avi';
   return String(raw).trim().slice(0, 1).toUpperCase();
@@ -172,7 +167,6 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
         <span className="connectome-context-label connectome-context-label--ambient" aria-live="polite">{appLabels[activeApp] || 'Ora'}</span>
 
         <div className="connectome-status">
-          <span className="connectome-xp">LVL {xpLevel(profile)}</span>
           <button type="button" className="connectome-bell" aria-label="Notifications">🔔</button>
           <button type="button" className="connectome-avatar" onClick={() => navigate('/app/profile')} aria-label="Open profile">
             {initials(profile)}


### PR DESCRIPTION
## Summary
- Remove visible XP/level from the Connectome shell top bar
- Soften profile progress into milestone progress without score-like XP totals
- Remove XP labels from skill trees, celebrations, share copy, home highlights, and feed toasts
- Keep backend gamification/progress calls intact for personalization signals
- Keep CP contribution surfaces visible

## Verification
- npm run build