### PR TITLE
Clarify Connectome UX flow

### DIFF
--- a/docs/UX_FLOW.md
+++ b/docs/UX_FLOW.md
@@ -1,0 +1,146 @@
+# Connectome / iDo UX Flow
+
+## Product hierarchy
+
+- **Ascension** = the DAO and mission ecosystem. It explains why the work matters, hosts contribution culture, and points people toward governance/community.
+- **Connectome** = the AIOS. It connects the user's life context, apps, DAO identity, and semantic graph into one operating system.
+- **Ora** = the brain/interface. Ora clarifies intent, answers questions, routes users, and sits contextually in the shell.
+- **iDo** = the daily app. It gives the user one useful next action when they do not know what to do.
+
+Public site (`web/atdao`) is the Ascension/DAO front door. GitHub Pages `connectome-web` remains the app surface until the domain strategy changes.
+
+## Current audit summary
+
+### Confusing/broken patterns found
+
+- Auth success and several internal links still used legacy routes (`/feed`, `/home`, `/dao`, `/contribute`) even though the app IA now lives under `/app/*`.
+- `/app` had no canonical route; only `/` authenticated rendered the orientation screen.
+- New users could finish onboarding on `/onboarding` and be left on an empty shell because the onboarding overlay hid itself without navigating onward.
+- Home showed app names and ambient signals, but not the two real first choices: “I know what I want” vs “I need a suggestion.”
+- The launcher used internal product labels first, which made it feel like architecture rather than user outcomes.
+- CP was explained from feedback, but contribution screens did not surface the same explanation clearly.
+- Profile/admin/system surfaces are mixed; they should remain reachable but not become a default path for ordinary users.
+
+## Primary user journeys
+
+### 1. First-time visitor → sign up → onboarding → home/feed
+
+1. Public entry explains Ascension/Connectome/iDo at a high level.
+2. User opens app and sees auth page: “iDo — your daily AI life app, guided by Ora.”
+3. Registration goes to `/onboarding` when the onboarding experiment asks for it; otherwise it lands at `/app`.
+4. Onboarding collects orientation signals.
+5. Completion lands at `/app`.
+6. `/app` asks the only important first question:
+   - “I know what I want to do” → `/app/goals?clarify=1`
+   - “I don’t know what I want to do” → `/app/ido`
+
+### 2. Returning user → home → choose goal/discovery → feed/action
+
+1. Login, OAuth callback, `/`, and `/app` land on the Connectome home/orientation screen.
+2. If the user has intent, Goals opens focused and invites them to clarify with Ora.
+3. If the user lacks intent, iDo opens the one-action feed.
+4. Feed cards support save/rate/skip/detail and route goal-building to `/app/goals`.
+
+### 3. User wants feedback → CP explainer → feedback submit
+
+1. Global `?` feedback FAB is available in the shell.
+2. Feedback modal answers “what do I send?” and “why would I do this?”
+3. “What is CP?” opens the CP explainer.
+4. Submit sends route, optional screenshot, category, and text; reward feedback is shown in toast.
+
+### 4. User wants to contribute → DAO/contribute/GitHub
+
+1. `/app/dao` explains DAO, CP, governance, proposals, leaderboard, and contribution status.
+2. Primary CTA opens `/app/contribute`.
+3. `/app/contribute` explains what contribution evidence is needed and links the CP explainer.
+4. Code contributions require GitHub connection; GitHub callback returns to `/app/contribute?github=connected`.
+
+### 5. User wants to understand CP/DAO/Ascension/Connectome/Ora/iDo
+
+1. Public site = Ascension/DAO mission.
+2. App home = short product hierarchy in the first screen.
+3. DAO page = governance and contribution economy.
+4. CP explainer = reward/reputation mechanism.
+5. Ora overlay = contextual guide, not primary navigation.
+
+## Route map
+
+### Auth and callbacks
+
+- `/` — unauthenticated auth page; authenticated Connectome/iDo home.
+- `/auth/callback` — Google OAuth callback; stores auth and redirects to `/app`.
+- `/auth/github-callback` — GitHub connection callback; redirects to `/app/contribute?github=connected`.
+- `/onboarding` — authenticated Ora onboarding; completion redirects to `/app`.
+
+### Authenticated app
+
+- `/app` — Home/orientation screen.
+- `/app/ido` — one-action feed/discovery.
+- `/app/goals` — goals and Ora clarification.
+- `/app/routines` — routines and habits.
+- `/app/dao` — DAO, CP, proposals, governance, contribution overview.
+- `/app/contribute` — submit contributions and sync GitHub.
+- `/app/profile` — personal profile, settings, admin/system tools when available.
+- `/app/services` — Ora-powered tools and generated surfaces.
+- `/app/ioo` — IOO semantic graph/map.
+- `/app/ivive` — vitality domain.
+- `/app/eviva` — mission/service domain.
+- `/surfaces/:surfaceId` — auth-gated generated surface.
+
+### Backward-compatible redirects
+
+- `/home` → `/app`
+- `/feed`, `/discover`, `/journal` → `/app/ido`
+- `/goals` → `/app/goals`
+- `/routines` → `/app/routines`
+- `/dao` → `/app/dao`
+- `/contribute` → `/app/contribute`
+- `/services` → `/app/services`
+- `/profile` → `/app/profile`
+- `/ora` → `/app`
+
+## Screen purposes, first 5 seconds, CTAs
+
+| Screen | Purpose | Must answer in 5 seconds | Primary CTA | Secondary CTA |
+|---|---|---|---|---|
+| Auth | Sign in/up to iDo/Ora | “This is my daily AI life app.” | Continue with Google / Sign in | Register |
+| `/app` Home | Orient the user and route intent | “Choose goal clarification or discovery.” | Clarify with Ora | Open iDo feed |
+| `/app/ido` | Present one next action | “Here is something I can do now.” | Act/save/rate card | Skip / make it a goal |
+| `/app/goals` | Convert intent into structured path | “Tell Ora what you want.” | Start clarification | Pick a starter |
+| `/app/dao` | Explain contribution economy/governance | “This is how the ecosystem is governed and rewarded.” | Open Contribute | Browse issues/proposals |
+| `/app/contribute` | Submit evidence of work | “Submit concrete work and earn CP.” | Submit contribution | Connect GitHub / What is CP? |
+| `/app/profile` | Identity, settings, system/admin | “This is my account and controls.” | Manage profile/settings | Open admin/system sections |
+| `/app/services` | Tools and surfaces | “Use or generate Ora-powered tools.” | Open tool/surface | Ask Ora |
+| `/app/ioo` | Semantic map | “This is Ora’s life graph.” | Explore map | Return to goals/iDo |
+| `/app/ivive` | Vitality domain | “Improve energy/body/mind.” | Start vitality action | Ask Ora |
+| `/app/eviva` | Mission/service domain | “Find meaningful contribution.” | Explore missions/services | Contribute |
+
+## Navigation rules
+
+- **Home is the orientation hub**: `/` when authenticated and `/app` both render it.
+- **Dock is local navigation**: show the 4–5 most relevant neighbouring actions for the current app. Keep Ora centered/contextual where possible.
+- **Launcher is global navigation**: hamburger opens all major surfaces using user-outcome labels, not internal architecture labels.
+- **Ora overlay is contextual assistance**: use for questions, clarification, and routing help; do not make it the only way to move between screens.
+- **Profile is identity/settings**: admin/dev/system tools may live there for now but should not be primary user navigation.
+- **Legacy routes redirect** rather than render duplicate screens.
+
+## Error, empty, and loading states
+
+- **Auth**: show backend error; return to auth page after callback failure.
+- **Onboarding**: if already complete, redirect to `/app`; if API fails, avoid trapping user in a blank shell.
+- **Home**: static orientation should render without API dependency.
+- **Feed**: loading should communicate that Ora is preparing actions; empty should offer goals and feedback.
+- **Goals**: skeleton while loading; empty state invites starter or typed goal; failed Ora clarification should show toast.
+- **DAO**: empty leaderboard/proposals explain what to do next, not just “none.”
+- **Contribute**: unauthenticated submit disabled with sign-in copy; code contribution requires GitHub; success/error messages stay inline.
+- **Feedback**: screenshot capture is optional; failed submit shows retryable error.
+
+## First-pass implementation made with this spec
+
+- Added canonical `/app` route.
+- Auth login, OAuth callback, and onboarding completion now land on `/app`.
+- GitHub callback now returns to `/app/contribute`.
+- Cleaned app-internal legacy navigation links to `/app/*`.
+- Reworked Home into the two-choice orientation screen.
+- Changed launcher copy to user outcomes.
+- Added CP explainer access from Contribute.

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -20,22 +20,22 @@ import { useAuth } from '../context/AuthContext';
 
 // ─── Mobile 5-tab config (WeChat pattern) ────────────────────────────────────
 const MOBILE_TABS = [
-  { path: '/feed',    icon: '◉',  label: 'Discover' },
-  { path: '/goals',   icon: '◎',  label: 'Goals'    },
-  { path: '/ora',     icon: null, label: 'Ora',  isOra: true },
-  { path: '/dao',     icon: '🏛', label: 'DAO'      },
-  { path: '/profile', icon: null, label: 'Me',   isProfile: true },
+  { path: '/app/ido',    icon: '◉',  label: 'Discover' },
+  { path: '/app/goals',   icon: '◎',  label: 'Goals'    },
+  { path: '/app',     icon: null, label: 'Ora',  isOra: true },
+  { path: '/app/dao',     icon: '🏛', label: 'DAO'      },
+  { path: '/app/profile', icon: null, label: 'Me',   isProfile: true },
 ] as const;
 
 // ─── Desktop sidebar config ───────────────────────────────────────────────────
 const SIDEBAR_ITEMS = [
-  { path: '/home',       icon: '◉',  label: 'Home'       },
-  { path: '/feed',       icon: '✦',  label: 'Discover'   },
-  { path: '/ora',        icon: '◈',  label: 'Ora',        special: true },
-  { path: '/goals',      icon: '◎',  label: 'Goals'      },
-  { path: '/dao',        icon: '🏛', label: 'DAO'        },
-  { path: '/contribute', icon: '✚',  label: 'Contribute' },
-  { path: '/profile',    icon: null, label: 'Me',         isProfile: true },
+  { path: '/app',       icon: '◉',  label: 'Home'       },
+  { path: '/app/ido',       icon: '✦',  label: 'Discover'   },
+  { path: '/app',        icon: '◈',  label: 'Ora',        special: true },
+  { path: '/app/goals',      icon: '◎',  label: 'Goals'      },
+  { path: '/app/dao',        icon: '🏛', label: 'DAO'        },
+  { path: '/app/contribute', icon: '✚',  label: 'Contribute' },
+  { path: '/app/profile',    icon: null, label: 'Me',         isProfile: true },
 ] as const;
 
 const TIER_COLORS: Record<string, string> = {
@@ -53,14 +53,14 @@ export function NavBar() {
 
   // More menu items for Me tab
   const ME_MORE = [
-    { path: '/dao',        icon: '🏛', label: 'DAO & Contributions' },
-    { path: '/contribute', icon: '✚', label: 'Contribute & Earn' },
-    { path: '/home',       icon: '◉', label: 'Home' },
+    { path: '/app/dao',        icon: '🏛', label: 'DAO & Contributions' },
+    { path: '/app/contribute', icon: '✚', label: 'Contribute & Earn' },
+    { path: '/app',       icon: '◉', label: 'Home' },
   ];
 
   const MAP_MORE = [
     { path: '/ioo',      icon: '🗺', label: 'IOO Map' },
-    { path: '/goals',    icon: '◎', label: 'Goals' },
+    { path: '/app/goals',    icon: '◎', label: 'Goals' },
   ];
   const lastScrollY = useRef(0);
   const ticking = useRef(false);
@@ -225,7 +225,7 @@ export function NavBar() {
           }}>
             {MOBILE_TABS.map((tab) => {
               const isActive = location.pathname === tab.path ||
-                (tab.path === '/feed' && location.pathname === '/');
+                (tab.path === '/app/ido' && location.pathname === '/');
 
               if ((tab as any).isOra) {
                 // ─── Center Ora button — elevated like WeChat "+" ──────────

--- a/src/components/OraOnboarding.tsx
+++ b/src/components/OraOnboarding.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { OraClient, OnboardingMessage } from '../lib/OraClient';
 
 interface ChatMessage extends OnboardingMessage {
@@ -59,6 +60,7 @@ export default function OraOnboarding() {
   const [renderHint, setRenderHint] = useState<string | null>(null);
   const [energyScores, setEnergyScores] = useState({ iVive: 5, Eviva: 5, Aventi: 5 });
   const [checked, setChecked] = useState(false);
+  const navigate = useNavigate();
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -67,6 +69,7 @@ export default function OraOnboarding() {
     const boot = async () => {
       if (localStorage.getItem(ONBOARDING_CACHE_KEY) === 'true') {
         setChecked(true);
+        navigate('/app', { replace: true });
         return;
       }
       try {
@@ -75,6 +78,7 @@ export default function OraOnboarding() {
         if (status.completed) {
           localStorage.setItem(ONBOARDING_CACHE_KEY, 'true');
           setChecked(true);
+          navigate('/app', { replace: true });
           return;
         }
         setVisible(true);
@@ -100,7 +104,7 @@ export default function OraOnboarding() {
     };
     boot();
     return () => { cancelled = true; };
-  }, []);
+  }, [navigate]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -126,7 +130,7 @@ export default function OraOnboarding() {
       if (res.is_complete) {
         setComplete(true);
         localStorage.setItem(ONBOARDING_CACHE_KEY, 'true');
-        window.setTimeout(() => setVisible(false), 1500);
+        window.setTimeout(() => navigate('/app', { replace: true }), 1500);
       }
     } catch (e) {
       console.error('Onboarding send failed:', e);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,6 +53,7 @@ function App() {
           <Route path="/auth/github-callback" element={<GitHubCallbackPage />} />
 
           {/* AIOS app routes */}
+          <Route path="/app" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
           <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
           <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
           <Route path="/app/routines" element={<ShellRoute activeApp="routines"><RoutinesPage /></ShellRoute>} />
@@ -67,13 +68,13 @@ function App() {
           <Route path="/onboarding" element={<ShellRoute activeApp="home"><OraOnboarding /></ShellRoute>} />
 
           {/* Backward-compatible redirects */}
-          <Route path="/home" element={<Navigate to="/" replace />} />
+          <Route path="/home" element={<Navigate to="/app" replace />} />
           <Route path="/feed" element={<Navigate to="/app/ido" replace />} />
           <Route path="/discover" element={<Navigate to="/app/ido" replace />} />
           <Route path="/goals" element={<Navigate to="/app/goals" replace />} />
           <Route path="/routines" element={<Navigate to="/app/routines" replace />} />
           <Route path="/journal" element={<Navigate to="/app/ido" replace />} />
-          <Route path="/ora" element={<Navigate to="/" replace />} />
+          <Route path="/ora" element={<Navigate to="/app" replace />} />
           <Route path="/dao" element={<Navigate to="/app/dao" replace />} />
           <Route path="/contribute" element={<Navigate to="/app/contribute" replace />} />
           <Route path="/services" element={<Navigate to="/app/services" replace />} />

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -4,7 +4,7 @@
  * Google → Railway backend → redirects to:
  *   https://avielcarlos.github.io/connectome-web/auth/callback?token=<jwt>
  *
- * This page reads the token from the URL, stores it, and redirects to /feed.
+ * This page reads the token from the URL, stores it, and redirects to the app home.
  * If there's an error param instead, it shows an error and redirects to login.
  */
 import { useEffect, useState } from 'react';
@@ -41,8 +41,8 @@ export default function AuthCallbackPage() {
       if (!userId) throw new Error('No user ID in token');
 
       authStorage.setAuth(token, userId);
-      // Small delay to let state settle, then redirect to feed
-      setTimeout(() => navigate('/feed', { replace: true }), 100);
+      // Small delay to let state settle, then redirect to the orientation home
+      setTimeout(() => navigate('/app', { replace: true }), 100);
     } catch (e: any) {
       setError(`Token error: ${e.message}`);
       setTimeout(() => navigate('/', { replace: true }), 3000);

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -34,14 +34,13 @@ export default function AuthPage() {
     try {
       if (mode === 'login') {
         await login(email, password);
-        navigate('/feed');
+        navigate('/app', { replace: true });
       } else {
         await register(email, password, displayName || undefined);
         // A/B: login_after_register_destination
         const dest = postRegisterDestVariant === 'B' ? '/onboarding'
-          : postRegisterDestVariant === 'C' ? '/feed'
-          : '/home';
-        navigate(dest);
+          : '/app';
+        navigate(dest, { replace: true });
       }
     } catch (err: any) {
       const msg = err?.response?.data?.detail || err?.message || 'Something went wrong';

--- a/src/pages/ConnectomeHome.tsx
+++ b/src/pages/ConnectomeHome.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { CONNECTOME_APPS } from '../shell/AppLauncher';
 
-const highlights = [
-  { label: 'Next IOO node', title: 'Clarify your next 24-hour move', meta: 'Ready when you are' },
-  { label: 'Pending challenge', title: 'Aventi discovery streak is waiting', meta: '12 minutes to start' },
-  { label: 'Signal from the network', title: '2 friends logged new intentions', meta: 'Reflect or join' },
-];
-
-const recent = [
-  'Ora mapped a fresh goal thread through the AIOS.',
-  'Ascension DAO contribution queue refreshed with new CP opportunities.',
-  'Aventi has 4 new experiences tuned to your current path.',
+const nextSignals = [
+  { label: 'Guided path', title: 'Turn a desire into a concrete next step', path: '/app/goals' },
+  { label: 'Discovery feed', title: 'Browse one doable action at a time', path: '/app/ido' },
+  { label: 'Community', title: 'Contribute to the ecosystem and earn CP', path: '/app/dao' },
 ];
 
 function greetingName(profile: any) {
@@ -27,47 +20,78 @@ function dayPart() {
   return 'evening';
 }
 
+const panel: React.CSSProperties = {
+  background: 'linear-gradient(180deg, rgba(18,18,26,0.94), rgba(12,12,18,0.94))',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: 24,
+  boxShadow: '0 20px 70px rgba(0,0,0,0.24)',
+};
+
 export default function ConnectomeHome() {
   const { profile } = useAuth();
   const navigate = useNavigate();
 
   return (
-    <div className="connectome-home">
-      <section className="connectome-home__hero">
+    <div className="connectome-home" style={{ maxWidth: 1040, margin: '0 auto', padding: '78px 18px 120px' }}>
+      <section className="connectome-home__hero" style={{ textAlign: 'center', marginBottom: 26 }}>
         <div className="connectome-home__signal">
           <span className="ora-orb" /> Ora is online
         </div>
         <h1>Your AI OS for Human Flourishing</h1>
-        <p>Daily guidance, vitality, experiences, missions, and community — orchestrated by Ora.</p>
-        <p>Good {dayPart()}, {greetingName(profile)}. Ora is orienting the OS around what matters next.</p>
+        <p style={{ maxWidth: 720, margin: '0 auto 10px' }}>
+          Good {dayPart()}, {greetingName(profile)}. This is the Connectome home base: choose whether you already know your aim, or want iDo to surface a next action.
+        </p>
       </section>
 
-      <section className="connectome-home__highlights" aria-label="Ora highlights">
-        {highlights.map((item) => (
-          <article key={item.label} className="connectome-home__highlight">
+      <section aria-label="Choose your next mode" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(270px, 1fr))', gap: 16, marginBottom: 24 }}>
+        <button
+          type="button"
+          onClick={() => navigate('/app/goals?clarify=1')}
+          style={{ ...panel, padding: 24, color: '#f8f8fc', textAlign: 'left', cursor: 'pointer' }}
+        >
+          <div style={{ color: '#00d4aa', fontSize: 12, fontWeight: 900, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>I know what I want to do</div>
+          <h2 style={{ margin: '0 0 10px', fontSize: 28, letterSpacing: -0.7 }}>Clarify it with Ora</h2>
+          <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)', lineHeight: 1.6 }}>Turn a goal, feeling, or problem into a concrete path with steps, constraints, and support.</p>
+          <div style={{ marginTop: 18, color: '#00d4aa', fontWeight: 900 }}>Start with a goal →</div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => navigate('/app/ido')}
+          style={{ ...panel, padding: 24, color: '#f8f8fc', textAlign: 'left', cursor: 'pointer' }}
+        >
+          <div style={{ color: '#f4c26b', fontSize: 12, fontWeight: 900, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>I don’t know what I want to do</div>
+          <h2 style={{ margin: '0 0 10px', fontSize: 28, letterSpacing: -0.7 }}>Let iDo suggest one action</h2>
+          <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)', lineHeight: 1.6 }}>Open the discovery feed and choose, save, skip, or act on one useful possibility at a time.</p>
+          <div style={{ marginTop: 18, color: '#f4c26b', fontWeight: 900 }}>Open iDo feed →</div>
+        </button>
+      </section>
+
+      <section aria-label="What this is" style={{ ...panel, padding: 22, marginBottom: 24 }}>
+        <div style={{ color: '#00d4aa', fontSize: 12, fontWeight: 900, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 10 }}>How the pieces fit</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 12 }}>
+          {[
+            ['Ascension', 'The DAO and mission ecosystem.'],
+            ['Connectome', 'The AIOS that connects your life context.'],
+            ['Ora', 'The brain and interface that helps you decide.'],
+            ['iDo', 'The daily app for one next action.'],
+          ].map(([name, copy]) => (
+            <div key={name} style={{ background: 'rgba(255,255,255,0.035)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 16, padding: 15 }}>
+              <strong>{name}</strong>
+              <p style={{ margin: '6px 0 0', color: 'rgba(248,248,252,0.58)', fontSize: 13, lineHeight: 1.5 }}>{copy}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="connectome-home__highlights" aria-label="Next places">
+        {nextSignals.map((item) => (
+          <button key={item.label} className="connectome-home__highlight" type="button" onClick={() => navigate(item.path)} style={{ textAlign: 'left', cursor: 'pointer' }}>
             <span>{item.label}</span>
             <h3>{item.title}</h3>
-            <p>{item.meta}</p>
-          </article>
-        ))}
-      </section>
-
-      <section className="connectome-home__apps" aria-label="Ora apps">
-        <h2>Ora apps</h2>
-        {CONNECTOME_APPS.filter((app) => !app.soon && !app.external).slice(0, 5).map((app) => (
-          <button key={app.name} type="button" onClick={() => navigate(app.path)}>
-            <span>{app.icon}</span>
-            <strong>{app.name}</strong>
+            <p>Open →</p>
           </button>
         ))}
-      </section>
-
-      <section className="connectome-home__activity">
-        <div>
-          <span>Recent activity</span>
-          <h2>Light signals from the OS</h2>
-        </div>
-        {recent.map((entry) => <p key={entry}>{entry}</p>)}
       </section>
     </div>
   );

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { OraClient, authStorage } from '../lib/OraClient';
+import CPExplainerModal from '../components/CPExplainerModal';
 
 const ACCENT = '#00d4aa';
 
@@ -54,6 +55,7 @@ export default function ContributePage() {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [githubStatus, setGithubStatus] = useState<GitHubStatus>({ connected: false, github_username: null, github_avatar_url: null });
+  const [cpExplainerOpen, setCpExplainerOpen] = useState(false);
 
   const isAuthed = useMemo(() => authStorage.isAuthenticated(), []);
 
@@ -148,6 +150,7 @@ export default function ContributePage() {
           <div style={{ display: 'inline-flex', border: '1px solid rgba(0,212,170,0.28)', background: 'rgba(0,212,170,0.08)', color: ACCENT, borderRadius: 999, padding: '7px 12px', fontSize: 12, fontWeight: 900, letterSpacing: 0.9, textTransform: 'uppercase', marginBottom: 16 }}>Internal ecosystem workbench</div>
           <h1 style={{ fontSize: 'clamp(36px, 7vw, 70px)', lineHeight: 0.98, letterSpacing: -2.2, margin: '0 0 16px', fontWeight: 950 }}>Submit work. Earn CP. Move the ecosystem forward.</h1>
           <p style={{ margin: '0 auto', maxWidth: 690, color: 'rgba(248,248,252,0.62)', fontSize: 17, lineHeight: 1.65 }}>Contribute is the workbench: concrete tasks, evidence, review, and delivery. DAO governs and rewards the work; Eviva handles world-facing missions and opportunities.</p>
+          <button type="button" onClick={() => setCpExplainerOpen(true)} style={{ marginTop: 14, color: ACCENT, fontWeight: 900, textDecoration: 'none' }}>What is CP?</button>
         </section>
 
         <section style={{ ...card, padding: 22, marginBottom: 22 }}>
@@ -218,6 +221,7 @@ export default function ContributePage() {
           <ul style={{ margin: '16px 0 0', paddingLeft: 20, color: 'rgba(248,248,252,0.66)', lineHeight: 1.75 }}><li>Quality over quantity.</li><li>Must be implemented or documented evidence of real work.</li><li>Ora reviews every submission within 24h.</li><li>CP awarded based on impact and complexity.</li></ul>
         </details>
       </div>
+      <CPExplainerModal open={cpExplainerOpen} onClose={() => setCpExplainerOpen(false)} />
     </main>
   );
 }

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -325,7 +325,7 @@ function FeedCard({
         {/* Card content */}
         {spec.components.map((comp: any, i: number) => (
           <OraCard key={i} component={comp} index={i} onAction={(action: any) => {
-            if (action.type === 'navigate' && action.url === '/goals') navigate('/goals');
+            if (action.type === 'navigate' && action.url === '/app/goals') navigate('/app/goals');
           }} />
         ))}
 
@@ -858,7 +858,7 @@ export default function FeedPage() {
             <div style={{ fontSize: 14, color: 'rgba(248,248,252,0.4)', maxWidth: 280, lineHeight: 1.7 }}>
               {dailyLimit} cards/day keeps insights sharp. Ora will have fresh ones ready tomorrow.
             </div>
-            <button onClick={() => navigate('/goals')} style={{
+            <button onClick={() => navigate('/app/goals')} style={{
               background: 'linear-gradient(135deg, #00d4aa, #00b896)',
               color: '#0a0a0f', padding: '14px 32px', borderRadius: 14,
               fontWeight: 800, fontSize: 16, marginTop: 8,
@@ -909,7 +909,7 @@ export default function FeedPage() {
         {streak && (
           <div
             style={{ pointerEvents: 'auto' }}
-            onClick={() => navigate('/profile')}
+            onClick={() => navigate('/app/profile')}
           >
             <StreakBadge compact />
           </div>

--- a/src/pages/GitHubCallbackPage.tsx
+++ b/src/pages/GitHubCallbackPage.tsx
@@ -1,4 +1,4 @@
-// Handles /auth/github-callback — shows "GitHub connected!" then redirects to /contribute
+// Handles /auth/github-callback — shows "GitHub connected!" then redirects to /app/contribute
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,7 +10,7 @@ export default function GitHubCallbackPage() {
     const connected = params.get('connected');
     void connected;
     // Slight delay, then go to contribute page
-    setTimeout(() => navigate('/contribute?github=connected'), 1500);
+    setTimeout(() => navigate('/app/contribute?github=connected'), 1500);
   }, [navigate]);
 
   return (

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -412,9 +412,9 @@ function QuickAddGoal({ onClarify }: { onClarify: (title: string) => void }) {
   };
   const goalPlaceholder = GOAL_PLACEHOLDERS[placeholderVariant] || GOAL_PLACEHOLDERS['A'];
 
-  // Auto-focus when navigated here from HomePage with ?focus=true
+  // Auto-focus when navigated here from Home with ?focus=true or ?clarify=1
   useEffect(() => {
-    if (searchParams.get('focus') === 'true') {
+    if (searchParams.get('focus') === 'true' || searchParams.get('clarify') === '1') {
       setTimeout(() => {
         inputRef.current?.focus();
         setFocused(true);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -145,7 +145,7 @@ export default function HomePage() {
 
     if (exploreVariant === 'instant') {
       OraClient.trackAbEvent('home_intake_v1', 'instant', 'intake_depth').catch(() => {});
-      setTimeout(() => navigate('/feed'), 180);
+      setTimeout(() => navigate('/app/ido'), 180);
       return;
     }
 
@@ -185,7 +185,7 @@ export default function HomePage() {
   const handleIntakeSubmit = () => {
     const variant = exploreVariant === 'deep' ? 'deep' : 'one_q';
     OraClient.trackAbEvent('home_intake_v1', variant, 'intake_depth').catch(() => {});
-    navigate('/feed');
+    navigate('/app/ido');
   };
 
   // ── View: creating ─────────────────────────────────────────────────────────

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -143,7 +143,7 @@ export default function ProfilePage() {
     localStorage.setItem(`ab_variant_${EXPERIMENT_ID}`, v);
     localStorage.setItem(`ab_variant_ts_${EXPERIMENT_ID}`, Date.now().toString());
     setCurrentVariant(v);
-    navigate('/feed');
+    navigate('/app/ido');
   };
 
   const loadSurfaces = async () => {
@@ -385,7 +385,7 @@ export default function ProfilePage() {
               <div style={{ fontWeight: 700, marginBottom: 6 }}>{upgradeHeadlineText}</div>
               <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.5)', marginBottom: 4 }}>Unlimited cards, Drive sync, local events</div>
               <div style={{ fontSize: 13, color: 'rgba(99,102,241,0.8)', fontWeight: 600, marginBottom: 12 }}>{upgradePriceText}</div>
-              <button onClick={() => { trackUpgradeCTA('click'); navigate('/dao'); }} style={{
+              <button onClick={() => { trackUpgradeCTA('click'); navigate('/app/dao'); }} style={{
                 background: '#6366f1', color: '#fff', padding: '9px 20px', borderRadius: 10, fontWeight: 700, fontSize: 13,
               }}>{upgradeCTAText}</button>
             </div>
@@ -394,9 +394,9 @@ export default function ProfilePage() {
           {/* ── Secondary Navigation — iOS Settings style ── */}
           <div style={{ background: '#12121e', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 16, overflow: 'hidden' }}>
             <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1, color: 'rgba(248,248,252,0.3)', textTransform: 'uppercase', padding: '14px 18px 6px' }}>Community</div>
-            <MenuRow icon="🏛" label="DAO & Contributions" sublabel="Earn CP, vote on proposals" onClick={() => navigate('/dao')} />
-            <MenuRow icon="✍" label="Journal" sublabel="Your personal log" onClick={() => navigate('/journal')} />
-            <MenuRow icon="⚡" label="Services" sublabel="Ora-powered tools" onClick={() => navigate('/services')} last />
+            <MenuRow icon="🏛" label="DAO & Contributions" sublabel="Earn CP, vote on proposals" onClick={() => navigate('/app/dao')} />
+            <MenuRow icon="✍" label="Journal" sublabel="Your personal log" onClick={() => navigate('/app/ido')} />
+            <MenuRow icon="⚡" label="Services" sublabel="Ora-powered tools" onClick={() => navigate('/app/services')} last />
           </div>
 
           <div style={{ background: '#12121e', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 16, overflow: 'hidden' }}>

--- a/src/pages/variants/VariantB.tsx
+++ b/src/pages/variants/VariantB.tsx
@@ -50,7 +50,7 @@ export default function VariantB() {
   const handleCTA = () => {
     OraClient.trackAbEvent(EXPERIMENT_ID, VARIANT, 'cta_tapped', 1).catch(() => {});
     sessionStorage.setItem('ab_skip', '1');
-    navigate('/feed');
+    navigate('/app/ido');
   };
 
   return (

--- a/src/pages/variants/VariantC.tsx
+++ b/src/pages/variants/VariantC.tsx
@@ -47,7 +47,7 @@ export default function VariantC() {
 
   const trackAndNavigate = (eventType: string, path: string) => {
     OraClient.trackAbEvent(EXPERIMENT_ID, VARIANT, eventType, 1).catch(() => {});
-    if (path === '/feed') sessionStorage.setItem('ab_skip', '1');
+    if (path === '/app/ido') sessionStorage.setItem('ab_skip', '1');
     navigate(path);
   };
 
@@ -83,7 +83,7 @@ export default function VariantC() {
           Set your first goal and let Ora help you achieve it step by step.
         </div>
         <button
-          onClick={() => trackAndNavigate('set_first_goal', '/goals')}
+          onClick={() => trackAndNavigate('set_first_goal', '/app/goals')}
           style={{
             padding: '14px 36px',
             fontSize: 16,
@@ -203,19 +203,19 @@ export default function VariantC() {
       {/* Quick action buttons */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 380 }}>
         <button
-          onClick={() => trackAndNavigate('goal_engaged', '/goals')}
+          onClick={() => trackAndNavigate('goal_engaged', '/app/goals')}
           style={btnStyle(color)}
         >
           📊 Log progress
         </button>
         <button
-          onClick={() => trackAndNavigate('goal_engaged', '/ora')}
+          onClick={() => trackAndNavigate('goal_engaged', '/app')}
           style={btnStyle('#a855f7')}
         >
           💬 Ask Ora
         </button>
         <button
-          onClick={() => trackAndNavigate('feed_opened', '/feed')}
+          onClick={() => trackAndNavigate('feed_opened', '/app/ido')}
           style={{ ...btnStyle('rgba(255,255,255,0.12)'), color: 'rgba(248,248,252,0.7)' }}
         >
           📰 See Feed

--- a/src/shell/AppLauncher.tsx
+++ b/src/shell/AppLauncher.tsx
@@ -18,6 +18,20 @@ interface AppLauncherProps {
 
 const DEFAULT_FEATURED_APPS = ['iDo', 'Aventi', 'iVive', 'Eviva'];
 
+const OUTCOME_LABELS: Partial<Record<ConnectomeApp['id'], { title: string; description: string; badge?: string }>> = {
+  ido: { title: 'Find one thing to do now', description: 'A simple action feed when you want momentum but not more planning.', badge: 'Daily' },
+  goals: { title: 'Clarify a goal with Ora', description: 'Turn an intention into steps, constraints, and a path you can act on.', badge: 'Plan' },
+  routines: { title: 'Build a repeatable rhythm', description: 'Make the helpful action automatic with small routines.', badge: 'Habits' },
+  ivive: { title: 'Improve vitality', description: 'Care for energy, health, recovery, and inner stability.', badge: 'Vitality' },
+  eviva: { title: 'Serve a meaningful mission', description: 'Find contribution, work, services, and world-facing opportunities.', badge: 'Mission' },
+  aventi: { title: 'Discover life experiences', description: 'Open adventures, events, friends, dating, and spontaneity.', badge: 'External' },
+  dao: { title: 'Understand the DAO', description: 'See governance, CP, proposals, and the contribution economy.', badge: 'DAO' },
+  contribute: { title: 'Submit work and earn CP', description: 'Share code, design, research, ideas, or feedback for review.', badge: 'Build' },
+  services: { title: 'Use Ora-powered tools', description: 'Open integrations and generated surfaces around your current path.', badge: 'Tools' },
+  ioo: { title: 'View the life map', description: 'Explore the graph Ora uses to reason about what matters next.', badge: 'Map' },
+  profile: { title: 'Manage identity and settings', description: 'Control profile, accounts, permissions, experiments, and system tools.', badge: 'You' },
+};
+
 export default function AppLauncher({ onLaunch }: AppLauncherProps) {
   const navigate = useNavigate();
   const [aiosState, setAiosState] = useState<AiosState>({ featured_apps: DEFAULT_FEATURED_APPS });
@@ -60,8 +74,8 @@ export default function AppLauncher({ onLaunch }: AppLauncherProps) {
   return (
     <section className="app-launcher" aria-label="App launcher">
       <div className="app-launcher__intro">
-        <span>Ora</span>
-        <h2>Choose where Ora should focus.</h2>
+        <span>Connectome</span>
+        <h2>What are you trying to do?</h2>
         {aiosState.ora_mission_statement && (
           <p className="app-launcher__mission">{aiosState.ora_mission_statement}</p>
         )}
@@ -77,10 +91,10 @@ export default function AppLauncher({ onLaunch }: AppLauncherProps) {
               className={`app-launcher__card ${isFeatured ? 'app-launcher__card--featured' : ''}`}
               onClick={() => launch(app)}
             >
-              {isFeatured && <span className="app-launcher__featured-badge">Featured</span>}
+              {isFeatured && <span className="app-launcher__featured-badge">{OUTCOME_LABELS[app.id]?.badge || 'Featured'}</span>}
               <span className="app-launcher__icon">{app.icon}</span>
-              <span className="app-launcher__name">{app.name}</span>
-              <span className="app-launcher__description">{app.description}</span>
+              <span className="app-launcher__name">{OUTCOME_LABELS[app.id]?.title || app.name}</span>
+              <span className="app-launcher__description">{OUTCOME_LABELS[app.id]?.description || app.description}</span>
               {app.external && <span className="app-launcher__soon">Opens externally</span>}
             </button>
           );


### PR DESCRIPTION
## Summary\n- Add docs/UX_FLOW.md with product hierarchy, route map, primary journeys, screen CTAs, navigation rules, and states\n- Add canonical /app home route and redirect auth/onboarding/callback success paths there\n- Rework home into a two-choice orientation screen and update launcher copy to outcome-focused labels\n- Clean legacy app links to /app/* and surface CP explainer from Contribute\n\n## Validation\n- npm run build