### PR TITLE
fix(feed): remove manual opportunity node add UI

### DIFF
--- a/src/lib/AuraClient.ts
+++ b/src/lib/AuraClient.ts
@@ -370,23 +370,6 @@ class AuraClientClass {
     }
   }
 
-  async createOpportunity(payload: {
-    title: string;
-    body?: string;
-    kind?: string;
-    domain?: 'iVive' | 'Eviva' | 'Aventi';
-    city?: string;
-    url?: string;
-    source_url?: string;
-    booking_url?: string;
-    provider_url?: string;
-    map_url?: string;
-    price?: string;
-    venue?: string;
-  }): Promise<ScreenResponse> {
-    const res = await this.client.post('/api/screens/opportunities', payload);
-    return res.data as ScreenResponse;
-  }
 
   async getCityUnlock(city = 'Victoria, BC') {
     const res = await this.client.get('/api/screens/city-unlock', { params: { city } });

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -685,68 +685,6 @@ function PathwaySheet({ data, onClose, onInvite }: { data: any; onClose: () => v
   );
 }
 
-function CreateOpportunitySheet({ onClose, onCreated }: { onClose: () => void; onCreated: (card: ScreenResponse) => void }) {
-  const [title, setTitle] = useState('');
-  const [url, setUrl] = useState('');
-  const [kind, setKind] = useState('Event / product / service');
-  const [domain, setDomain] = useState<'iVive' | 'Aventi' | 'Eviva'>('Aventi');
-  const [city, setCity] = useState<'Victoria, BC' | 'Vancouver, BC'>('Victoria, BC');
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
-
-  const submit = async () => {
-    if (!title.trim()) { setError('Add a title first.'); return; }
-    setSaving(true);
-    setError('');
-    try {
-      const created = await AuraClient.createOpportunity({
-        title: title.trim(),
-        body: `User/Aura-created local opportunity for ${city}. Verify links, cost, timing, and provider details before acting.`,
-        kind,
-        domain,
-        city,
-        url: url.trim() || undefined,
-        source_url: url.trim() || undefined,
-      });
-      onCreated(created);
-      onClose();
-    } catch (e: any) {
-      setError(e?.response?.data?.detail || 'Could not create this opportunity yet.');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(0,0,0,0.72)', backdropFilter: 'blur(12px)', display: 'flex', alignItems: 'flex-end', paddingBottom: 'var(--shell-bottom-clearance)' }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', background: '#11111c', borderRadius: '28px 28px 0 0', border: '1px solid rgba(0,212,170,0.24)', padding: '20px 22px 34px' }}>
-        <div style={{ width: 44, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.16)', margin: '0 auto 18px' }} />
-        <div style={{ color: '#00d4aa', fontSize: 12, fontWeight: 950, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>Create with Aura · BC corridor beta</div>
-        <h2 style={{ margin: 0, color: '#f8f8fc', fontSize: 24 }}>Add a real opportunity</h2>
-        <p style={{ color: 'rgba(248,248,252,0.56)', lineHeight: 1.55, fontSize: 13 }}>Add events, products, services, classes, bookings, developer channels, providers, or local nodes Aura missed in Victoria or Vancouver. Links are optional but strongly preferred.</p>
-        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title — e.g. Pottery class at..." style={{ width: '100%', boxSizing: 'border-box', marginTop: 10, padding: '13px 14px', borderRadius: 14, background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc', fontSize: 15 }} />
-        <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="Page / booking / provider URL" style={{ width: '100%', boxSizing: 'border-box', marginTop: 10, padding: '13px 14px', borderRadius: 14, background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc', fontSize: 15 }} />
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 10 }}>
-          <select value={kind} onChange={(e) => setKind(e.target.value)} style={{ padding: '12px 10px', borderRadius: 14, background: '#171725', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc' }}>
-            <option>Event</option><option>Class</option><option>Product</option><option>Service</option><option>Booking</option><option>Volunteer role</option><option>Developer channel</option><option>Path node</option>
-          </select>
-          <select value={domain} onChange={(e) => setDomain(e.target.value as any)} style={{ padding: '12px 10px', borderRadius: 14, background: '#171725', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc' }}>
-            <option value="Aventi">Aventi</option><option value="iVive">iVive</option><option value="Eviva">Eviva</option>
-          </select>
-        </div>
-        <select value={city} onChange={(e) => setCity(e.target.value as any)} style={{ width: '100%', marginTop: 10, padding: '12px 10px', borderRadius: 14, background: '#171725', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc' }}>
-          <option value="Victoria, BC">Victoria, BC</option>
-          <option value="Vancouver, BC">Vancouver, BC</option>
-        </select>
-        {error && <div style={{ marginTop: 10, color: '#fca5a5', fontSize: 12 }}>{error}</div>}
-        <button disabled={saving} onClick={submit} style={{ marginTop: 14, width: '100%', minHeight: 52, border: 'none', borderRadius: 999, background: 'linear-gradient(135deg,#00d4aa,#14f1c1)', color: '#06110f', fontSize: 15, fontWeight: 950 }}>
-          {saving ? 'Creating…' : 'Create opportunity node →'}
-        </button>
-      </div>
-    </div>
-  );
-}
-
 // ─── Full-bleed FeedCard ─────────────────────────────────────────────────────
 function FeedCard({
   item,
@@ -1136,7 +1074,6 @@ export default function FeedPage() {
   const [domainFilter, setDomainFilter] = useState<PathDomainFilter>(PATH_DOMAIN_TABS.some((tab) => tab.id === requestedDomain) ? requestedDomain : null);
   const [feedMode, setFeedMode] = useState<FeedMode>(requestedMode);
   const [timeHorizon, setTimeHorizon] = useState<TimeHorizonId>(initialTimeHorizon);
-  const [showCreateOpportunity, setShowCreateOpportunity] = useState(false);
 
   const touchStartY = useRef<number | null>(null);
   const touchStartX = useRef<number | null>(null);
@@ -1555,17 +1492,6 @@ export default function FeedPage() {
       {/* Collection picker */}
       {pathwaySheet && <PathwaySheet data={pathwaySheet} onClose={() => setPathwaySheet(null)} onInvite={() => handleInvite(pathwaySheet.item, pathwaySheet.card)} />}
 
-      {showCreateOpportunity && (
-        <CreateOpportunitySheet
-          onClose={() => setShowCreateOpportunity(false)}
-          onCreated={(card) => {
-            setCards((prev) => [card, ...prev]);
-            setIndex(0);
-            showToast('Opportunity node created');
-            setTimeout(() => scrollToIndex(0), 80);
-          }}
-        />
-      )}
 
       {collectionPickerCard && (
         <CollectionPicker
@@ -1685,18 +1611,6 @@ export default function FeedPage() {
         )}
       </div>
 
-      {/* User-created opportunity entrypoint */}
-      <button
-        onClick={() => setShowCreateOpportunity(true)}
-        style={{
-          position: 'absolute', top: 'max(env(safe-area-inset-top), 68px)', right: 14, zIndex: 36,
-          width: 42, height: 42, borderRadius: 21, border: '1px solid rgba(0,212,170,0.36)',
-          background: 'rgba(10,10,15,0.58)', color: '#00d4aa', backdropFilter: 'blur(16px)',
-          fontSize: 24, fontWeight: 800, lineHeight: '40px', boxShadow: '0 10px 34px rgba(0,0,0,0.28)',
-        }}
-        aria-label="Create opportunity with Aura"
-        title="Create opportunity with Aura"
-      >+</button>
 
       {/* Top header */}
       <div style={{


### PR DESCRIPTION
## Summary
- Removes the + floating button from the feed
- Removes the manual Add a real opportunity sheet
- Removes the now-unused frontend createOpportunity client method

## Product rationale
The system should create/expand IOO opportunity nodes autonomously from Aura, agents, events, feedback, execution outcomes, and graph learning — not ask users to manually add nodes from a plus button.

## Verification
- npm run build