### PR TITLE
fix(app): integrate feedback quick wins

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -626,7 +626,7 @@ body {
 .connectome-main {
   position: relative;
   min-height: var(--visual-viewport-height, 100dvh);
-  padding: calc(var(--top-header-height) + 10px) clamp(16px, 4vw, 44px) calc(var(--shell-bottom-clearance) + 18px);
+  padding: var(--shell-top-clearance) clamp(16px, 4vw, 44px) calc(var(--shell-bottom-clearance) + 18px);
 }
 
 .connectome-main--ido {
@@ -995,8 +995,17 @@ body.aura-chat-active.keyboard-open .ora-container {
 }
 
 @media (max-width: 760px) {
+  :root {
+    --shell-top-clearance: calc(var(--top-header-height) + max(18px, env(safe-area-inset-top, 0px)) + 14px);
+  }
+
   .connectome-topbar,
   .connectome-ambient-chrome { grid-template-columns: auto 1fr auto; padding-left: 12px; padding-right: 12px; }
+
+  .connectome-ambient-chrome {
+    background: linear-gradient(180deg, rgba(6, 6, 16, 0.72), rgba(6, 6, 16, 0.18) 70%, transparent);
+  }
+
   .connectome-brand small,
   .connectome-context-label,
   .connectome-ora-indicator span:last-child,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -422,7 +422,7 @@ export default function HomePage() {
               What area of life feels most alive right now?
             </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-              {['Career', 'Health', 'Relationships', 'Learning', 'Creative', 'Financial'].map((area) => (
+              {['Career', 'Health', 'Relationships', 'Learning', 'Creative', 'Fun', 'Entertainment', 'Adventure', 'Financial'].map((area) => (
                 <button key={area} onClick={() => setLifeArea(area)} style={{
                   padding: '9px 16px', borderRadius: 20, fontSize: 13, fontWeight: 600, cursor: 'pointer',
                   background: lifeArea === area ? 'rgba(0,212,170,0.12)' : 'rgba(255,255,255,0.04)',


### PR DESCRIPTION
## Summary\n- Adds Fun, Entertainment, and Adventure to the quick check-in life-area choices.\n- Increases mobile shell top clearance and adds a stronger top gradient so fixed chrome does not overlap important app content.\n\n## Feedback sources\n- Production user_suggestions: check-in should include fun/enjoyment/entertainment.\n- Production user_suggestions: top bar overlaps important app content.\n\n## Verification\n- npm run build\n- python3 scripts/guard_no_public_secrets.py\n\nRelated: #36, #37