### PR TITLE
fix(feedback): keep feedback trigger globally floating

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1129,11 +1129,11 @@ body.aura-chat-active.keyboard-open .ora-container {
 }
 
 /* Global in-app feedback loop */
-.global-feedback-fab { display: none; } /* FAB replaced by header button */
+.global-feedback-fab { display: none; } /* ConnectomeShell owns the universal floating trigger. */
 
 .connectome-feedback-btn {
-  width: 34px;
-  height: 34px;
+  width: 46px;
+  height: 46px;
   border-radius: 999px;
   border: 1px solid rgba(255,255,255,0.18);
   background: linear-gradient(135deg, #2563eb, #38bdf8);
@@ -1149,7 +1149,15 @@ body.aura-chat-active.keyboard-open .ora-container {
   transition: transform 150ms ease, box-shadow 150ms ease;
   flex-shrink: 0;
 }
+.connectome-feedback-btn--floating {
+  position: fixed;
+  top: calc(max(14px, env(safe-area-inset-top, 0px)) + 12px);
+  right: calc(max(14px, env(safe-area-inset-right, 0px)) + 12px);
+  z-index: 2300;
+  box-shadow: 0 14px 44px rgba(37,99,235,0.46), 0 0 0 6px rgba(5,10,24,0.38);
+}
 .connectome-feedback-btn:hover { transform: scale(1.06); box-shadow: 0 6px 18px rgba(37,99,235,0.5); }
+.connectome-feedback-btn--floating:hover { transform: scale(1.06); box-shadow: 0 16px 52px rgba(37,99,235,0.56), 0 0 0 6px rgba(5,10,24,0.44); }
 .connectome-feedback-btn:focus-visible { outline: 3px solid rgba(125,211,252,0.8); outline-offset: 3px; }
 
 .global-feedback-modal-backdrop {

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -216,17 +216,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
           <span className="connectome-context-label connectome-context-label--ambient" aria-live="polite">{appLabel(activeApp)}</span>
         )}
 
-        <div className="connectome-status">
-          <button
-            type="button"
-            className="connectome-feedback-btn"
-            data-feedback-widget="true"
-            aria-label="Send feedback"
-            onClick={() => setFeedbackOpen(true)}
-          >
-            !
-          </button>
-        </div>
+        <div className="connectome-status" />
       </header>
 
       <main className={`connectome-main connectome-main--${activeApp}`}>
@@ -265,6 +255,16 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
       )}
 
       <button className="connectome-signout" type="button" onClick={() => { logout(); navigate('/'); }}>Sign out</button>
+      <button
+        type="button"
+        className="connectome-feedback-btn connectome-feedback-btn--floating"
+        data-feedback-widget="true"
+        aria-label="Report a bug or make a suggestion"
+        title="Report a bug or make a suggestion"
+        onClick={() => setFeedbackOpen(true)}
+      >
+        !
+      </button>
       <GlobalFeedbackButton inlineMode inlineTrigger={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
       <AuraOverlay open={auraOpen} onClose={() => setAuraOpen(false)} />
       {locationPromptOpen && (


### PR DESCRIPTION
## Summary\n- Moves the ! feedback trigger out of the top chrome into a fixed global floating button.\n- Keeps it above app content on every Connectome page with safe-area-aware positioning.\n- Updates the label/title to support both bug reports and suggestions anywhere in the app.\n\n## Verification\n- npm run build\n- python3 scripts/guard_no_public_secrets.py\n\n## Risk\nLow: shell/CSS-only change, no backend or schema changes. Main UX risk is the floating button covering a small area in the top-right on very small screens; it is intentionally above content per product direction.