### PR TITLE
fix(feed): label future tab as Future

### DIFF
--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -22,7 +22,7 @@ function appLabel(appId: ShellApp) {
 
 const FEED_MODE_TABS = [
   { id: 'now', label: 'Now', emoji: '⚡', color: '#00d4aa', path: '/app/ido' },
-  { id: 'future', label: 'Later', emoji: '🔭', color: '#8b5cf6', path: '/app/future' },
+  { id: 'future', label: 'Future', emoji: '🔭', color: '#8b5cf6', path: '/app/future' },
 ] as const;
 
 type DockItem = {
@@ -195,7 +195,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
         </button>
 
         {activeApp === 'ido' ? (
-          <div className="connectome-domain-switch connectome-feed-mode-switch" aria-label="Now or Later feed">
+          <div className="connectome-domain-switch connectome-feed-mode-switch" aria-label="Now or Future feed">
             {FEED_MODE_TABS.map((tab) => {
               const active = activeFeedMode === tab.id;
               return (


### PR DESCRIPTION
## Summary\n- Reverts the feed mode label from Later to Future.\n- Updates the accessibility label to "Now or Future feed".\n\n## Verification\n- npm run build\n- python3 scripts/guard_no_public_secrets.py\n\n## Risk\nVery low: copy/accessibility-label-only change.