### PR TITLE
fix(shell): center Now/Future switcher

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -570,6 +570,9 @@ body {
 }
 
 .connectome-feed-mode-switch {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   grid-template-columns: repeat(2, minmax(0, 1fr));
   width: min(46vw, 260px);
 }


### PR DESCRIPTION
## Summary
- position the Now/Future switcher at the viewport center inside the top chrome
- prevents the left launcher/right status columns from visually pulling it off-centre

## Verification
- npm run build
- git diff --check
- light diff secret scan