### PR TITLE
fix(aura): make Aura a normal dock tab

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import AuthCallbackPage from './pages/AuthCallbackPage'
 import GitHubCallbackPage from './pages/GitHubCallbackPage'
 import ConnectomeHome from './pages/ConnectomeHome'
 import FeedPage from './pages/FeedPage'
+import AuraPage from './pages/OraPage'
 import GoalsPage from './pages/GoalsPage'
 import RoutinesPage from './pages/RoutinesPage'
 import DAOPage from './pages/DAOPage'
@@ -160,6 +161,7 @@ function App() {
           <Route path="/app" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
           <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
           <Route path="/app/future" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
+          <Route path="/app/ora" element={<ShellRoute activeApp="ora"><AuraPage /></ShellRoute>} />
           <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
           <Route path="/app/routines" element={<ShellRoute activeApp="routines"><RoutinesPage /></ShellRoute>} />
           <Route path="/app/dao" element={<ShellRoute activeApp="dao"><DAOPage /></ShellRoute>} />
@@ -184,7 +186,7 @@ function App() {
           <Route path="/goals" element={<Navigate to="/app/goals" replace />} />
           <Route path="/routines" element={<Navigate to="/app/routines" replace />} />
           <Route path="/journal" element={<Navigate to="/app/ido" replace />} />
-          <Route path="/ora" element={<Navigate to="/app" replace />} />
+          <Route path="/ora" element={<Navigate to="/app/ora" replace />} />
           <Route path="/dao" element={<Navigate to="/app/dao" replace />} />
           <Route path="/contribute" element={<Navigate to="/app/contribute" replace />} />
           <Route path="/profile" element={<Navigate to="/app/profile" replace />} />

--- a/src/pages/OraPage.tsx
+++ b/src/pages/OraPage.tsx
@@ -240,21 +240,11 @@ export default function AuraPage() {
         alignItems: 'center',
         justifyContent: 'space-between',
       }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          <div style={{
-            width: 40, height: 40, borderRadius: 12,
-            background: 'linear-gradient(135deg, rgba(0,212,170,0.15), rgba(0,212,170,0.35))',
-            border: '1px solid rgba(0,212,170,0.4)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: 20,
-            boxShadow: '0 0 16px rgba(0,212,170,0.15)',
-          }}>◈</div>
-          <div>
-            <div style={{ fontWeight: 800, fontSize: 16 }}>Aura</div>
-            <div style={{ fontSize: 11, color: '#00d4aa', display: 'flex', alignItems: 'center', gap: 4 }}>
-              <span style={{ width: 6, height: 6, borderRadius: 3, background: '#00d4aa', display: 'inline-block', animation: 'pulse 2s ease-in-out infinite' }} />
-              Online
-            </div>
+        <div>
+          <div style={{ fontWeight: 800, fontSize: 16 }}>Aura</div>
+          <div style={{ fontSize: 11, color: '#00d4aa', display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ width: 6, height: 6, borderRadius: 3, background: '#00d4aa', display: 'inline-block', animation: 'pulse 2s ease-in-out infinite' }} />
+            Online
           </div>
         </div>
         <button

--- a/src/runtime/ontology.ts
+++ b/src/runtime/ontology.ts
@@ -37,6 +37,7 @@ export interface PermissionGrant {
 export type AppId =
   | 'home'
   | 'ido'
+  | 'ora'
   | 'goals'
   | 'routines'
   | 'ivive'
@@ -368,6 +369,17 @@ export const FEED_SURFACES: FeedSurface[] = [
 
 // ─── App manifest (visible/invisible boundaries) ──────────────────────────────
 export const APP_MANIFEST: AppManifestEntry[] = [
+  {
+    id: 'ora',
+    name: 'Aura',
+    icon: '◈',
+    path: '/app/ora',
+    category: 'daily',
+    visibleToUser: true,
+    permissions: ['memory', 'notifications', 'files', 'calendar', 'location'],
+    description: 'Aura AI OS: the conversational guide and intelligence layer for Connectome.',
+    purpose: 'Lets users talk with Aura as a first-class tab while the bottom menu remains available for navigation.',
+  },
   {
     id: 'ido',
     name: 'Path Feed',

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -35,7 +35,7 @@ type DockItem = {
 
 const CORE_DOCK: DockItem[] = [
   { id: 'ido', label: 'iDo', icon: '⚡', path: '/app/ido' },
-  { id: 'ora', label: 'Aura', icon: '◈', action: 'aura' },
+  { id: 'ora', label: 'Aura', icon: '◈', path: '/app/ora' },
   { id: 'goals', label: 'Goals', icon: '🎯', path: '/app/goals' },
   { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },
 ];
@@ -43,6 +43,7 @@ const CORE_DOCK: DockItem[] = [
 const dockMenus: Partial<Record<ShellApp, DockItem[]>> = {
   home: CORE_DOCK,
   ido: CORE_DOCK,
+  ora: CORE_DOCK,
   goals: CORE_DOCK,
   routines: CORE_DOCK,
   dao: CORE_DOCK,


### PR DESCRIPTION
## Summary
- Changes the bottom dock Aura item from an overlay action into a normal `/app/ora` tab.
- Adds `/app/ora` routing for the Aura chat page with `activeApp=ora`, so the bottom dock remains visible and can be used to exit Aura by tapping another menu item.
- Adds Aura to the frontend app ontology/manifest.
- Removes the large orb from the Aura chat header so the tab has simpler chrome.
- Keeps the legacy Aura overlay available for contextual CTA buttons elsewhere, but the dock no longer opens it.

## Verification
- npm run build
- python3 scripts/guard_no_public_secrets.py
- git diff --check

## Risk
Low/medium: changes navigation behaviour for the Aura dock item from modal overlay to route/tab. This matches Avi’s direction, but users with stale app state may need refresh after deploy.
