### PR TITLE
fix(feed): keep Now general across goals

### DIFF
--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -35,17 +35,19 @@ const CAPABILITY_CARDS = [
   {
     id: 'goal_current_stage',
     field: 'goal_current_stage',
-    eyebrow: 'Goal state',
-    title: 'For {goal}, where are you right now?',
-    body: 'Goals describe the future. Aura needs the present-state gap before choosing the next IOO node.',
+    eyebrow: 'Present state',
+    title: 'What kind of node would help you right now?',
+    goalTitle: 'For {goal}, where are you right now?',
+    body: 'Aura uses your goals, values, energy, constraints, and resources before choosing the next IOO node.',
     options: ['Just starting', 'Preparing', 'Actively doing', 'Blocked/stuck', 'Recovering / low capacity'],
   },
   {
     id: 'goal_biggest_gap',
     field: 'goal_biggest_gap',
     eyebrow: 'Bridge signal',
-    title: 'What is the biggest gap between now and {goal}?',
-    body: 'This tells Aura whether to recommend a tiny action, a bridge step, support, practice, or a resource.',
+    title: 'What is the biggest gap between now and what matters?',
+    goalTitle: 'What is the biggest gap between now and {goal}?',
+    body: 'This tells Aura whether to recommend a tiny action, a bridge step, support, practice, connection, or a resource.',
     options: ['Time', 'Energy/health', 'Money/resources', 'Skill/confidence', 'People/support', 'Clarity/focus'],
   },
   {
@@ -86,7 +88,7 @@ const CAPABILITY_CARDS = [
     field: 'desired_next_step_style',
     eyebrow: 'Next move',
     title: 'What kind of next step would help most?',
-    body: 'Aura will use this to route the Now feed through the IOO graph.',
+    body: 'Aura will use this to route the Now feed across your goals, values, and nearby possibilities.',
     options: ['Tiny win', 'Practical progress', 'Learning/practice', 'Restore/regulate', 'Adventure/novelty', 'Service/connection'],
   },
 ];
@@ -291,7 +293,7 @@ function capabilityGoalToken(goalId?: string | null) {
 function todayCapabilityKey(goalId?: string | null) {
   return `ido_capability_pulse_${CAPABILITY_PULSE_VERSION}_${new Date().toISOString().slice(0, 10)}_${capabilityGoalToken(goalId)}`;
 }
-// Session key — cleared on window refresh, persists across tab switches, goal-aware
+// Session key — cleared on window refresh, persists across tab switches, context-aware
 function sessionCapabilityKey(goalId?: string | null) {
   return `ido_capability_pulse_session_${CAPABILITY_PULSE_VERSION}_${capabilityGoalToken(goalId)}`;
 }
@@ -302,8 +304,7 @@ function CapabilityIntake({ goalTitle, goalId, onComplete }: { goalTitle?: strin
   const [saving, setSaving] = useState(false);
   const card = CAPABILITY_CARDS[step];
   const chosen = selected[card.id] || [];
-  const goalLabel = goalTitle || 'your active goal';
-  const title = card.title.replace('{goal}', goalLabel);
+  const title = goalTitle && card.goalTitle ? card.goalTitle.replace('{goal}', goalTitle) : card.title;
 
   const choose = async (option: string) => {
     const nextChosen = card.multi
@@ -373,7 +374,7 @@ function CapabilityIntake({ goalTitle, goalId, onComplete }: { goalTitle?: strin
         )}
         <div style={{ marginTop: 18, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div style={{ color: 'rgba(248,248,252,0.34)', fontSize: 12, lineHeight: 1.55 }}>
-            Aura will refresh the Now feed around your goal, energy, constraints, and resources.
+            Aura will refresh Now around your goals, values, energy, constraints, and resources.
           </div>
           <button onClick={() => { sessionStorage.setItem(sessionCapabilityKey(goalId), '1'); onComplete(selected); }} style={{ background: 'transparent', border: 'none', color: 'rgba(248,248,252,0.3)', fontSize: 12, cursor: 'pointer', flexShrink: 0, marginLeft: 12 }}>
             Skip
@@ -1201,7 +1202,7 @@ export default function FeedPage() {
     }
   }, [searchParams]);
 
-  const feedContext = timeHorizonContext(feedMode, timeHorizon);
+  const feedContext = `${timeHorizonContext(feedMode, timeHorizon)} ${goalId ? 'GOAL-SPECIFIC feed: optimize recommendations for the selected goal only.' : 'GENERAL NOW feed: diversify node recommendations across all active goals plus value-aligned possibilities the user has not explicitly stated as goals. Do not imply the whole Now feed is only completing one goal.'}`;
 
   const updateTimeHorizon = (value: TimeHorizonId) => {
     setTimeHorizon(value);
@@ -1226,16 +1227,18 @@ export default function FeedPage() {
     try {
       const goals = await AuraClient.listGoals().catch(() => []);
       setHasGoals(goals.length > 0);
-      const focusedGoal = goalId ? goals.find((g: any) => g.id === goalId) : goals.find((g: any) => g.status === 'active') || goals[0];
+      const focusedGoal = goalId ? goals.find((g: any) => g.id === goalId) : null;
       if (focusedGoal?.title) setGoalTitle(focusedGoal.title);
-      const focusedGoalId = goalId || focusedGoal?.id;
+      else if (!goalId) setGoalTitle(null);
+      const focusedGoalId = goalId ? focusedGoal?.id : undefined;
       const batch = await AuraClient.getNextScreenBatch(5, focusedGoalId, undefined, feedContext, feedMode);
       let nextCards = enforceFeedMode(batch, feedMode, preferredCity);
       if (!nextCards.length) {
         const single = await AuraClient.getNextScreen(feedContext, focusedGoalId, undefined, feedMode).catch(() => null);
         nextCards = enforceFeedMode(single ? [single] : [], feedMode, preferredCity);
       }
-      // Prepend context intake card for Now feed if not answered this session
+      // Prepend context intake card for Now feed if not answered this session.
+      // The default Now feed is general; only a selected goal route passes goal context.
       if (!isFutureFeed && !sessionStorage.getItem(sessionCapabilityKey(focusedGoalId)) && !localStorage.getItem(todayCapabilityKey(focusedGoalId))) {
         const intakeCard = _buildIntakeCard(focusedGoal?.title || goalTitle, focusedGoalId);
         if (intakeCard) nextCards = [intakeCard, ...nextCards];

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -214,7 +214,7 @@ function LensTabs({ lens, setLens, counts }: { lens: Lens; setLens: (l: Lens) =>
   );
 }
 
-function GoalCard({ goal, onUpdate, onDelete }: { goal: Goal; onUpdate: (g: Goal) => void; onDelete: (id: string) => void }) {
+function GoalCard({ goal, onUpdate, onDelete, onOpenFeed }: { goal: Goal; onUpdate: (g: Goal) => void; onDelete: (id: string) => void; onOpenFeed: (goal: Goal) => void }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const [auraReply, setAuraReply] = useState('');
@@ -327,12 +327,13 @@ function GoalCard({ goal, onUpdate, onDelete }: { goal: Goal; onUpdate: (g: Goal
           </div>
         </button>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 10, alignItems: 'center', marginTop: 14 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto auto', gap: 10, alignItems: 'center', marginTop: 14 }}>
           <div style={{ minWidth: 0 }}>
             <div style={{ color: 'rgba(248,248,252,0.34)', fontSize: 10, fontWeight: 900, letterSpacing: 0.8, textTransform: 'uppercase' }}>Next measurable step</div>
             <div style={{ color: step ? 'rgba(248,248,252,0.78)' : 'rgba(248,248,252,0.42)', fontSize: 13, lineHeight: 1.35, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{step?.text || 'Needs Aura to turn the spark into a measurable goal'}</div>
           </div>
           <button onClick={step ? askAura : breakdown} disabled={!!busy} style={{ border: '1px solid rgba(0,212,170,0.35)', background: 'rgba(0,212,170,0.12)', color: '#00d4aa', borderRadius: 999, padding: '9px 12px', fontSize: 12, fontWeight: 900 }}>{busy ? '◈…' : step ? 'Refine' : 'Make measurable'}</button>
+          <button onClick={() => onOpenFeed(goal)} style={{ border: '1px solid rgba(139,92,246,0.35)', background: 'rgba(139,92,246,0.12)', color: '#c4b5fd', borderRadius: 999, padding: '9px 12px', fontSize: 12, fontWeight: 900 }}>Goal feed</button>
         </div>
 
         {open && (
@@ -513,7 +514,7 @@ export default function GoalsPage() {
       {loading ? (
         <div style={{ display: 'grid', gap: 12 }}>{[0, 1, 2].map((i) => <div key={i} className="skeleton" style={{ height: 132, borderRadius: 26 }} />)}</div>
       ) : visibleGoals.length ? (
-        <div>{visibleGoals.map((goal) => <GoalCard key={goal.id} goal={goal} onUpdate={handleUpdate} onDelete={handleDelete} />)}</div>
+        <div>{visibleGoals.map((goal) => <GoalCard key={goal.id} goal={goal} onUpdate={handleUpdate} onDelete={handleDelete} onOpenFeed={(g) => navigate(`/app/ido?goal=${encodeURIComponent(g.id)}`)} />)}</div>
       ) : goals.length ? (
         <div style={{ color: 'rgba(248,248,252,0.46)', textAlign: 'center', padding: 28 }}>Nothing in this lens yet.</div>
       ) : <EmptyState onClarify={setClarifyingGoal} />}


### PR DESCRIPTION
## Summary
- Stops the default Now feed from silently focusing on the first/active goal when no goal is selected.
- Updates the Now intake copy so it says Aura recommends across goals, values, energy, constraints, and resources — not one goal only.
- Adds explicit feed context: default Now = general multi-goal/value-aligned recommendations; `?goal=...` = goal-specific feed.
- Adds a `Goal feed` action on each Goals card that opens `/app/ido?goal=<goalId>` for the separate single-goal recommendation mode.

## Verification
- npm run build
- python3 scripts/guard_no_public_secrets.py
- git diff --check

## Risk
Medium-low: mostly copy and routing-context changes, plus one new Goals action. Backend recommendation quality still depends on how well it honors the strengthened feed context, so the next deeper improvement should teach the backend ranking layer to intentionally blend active goals + values in default Now.
