### PR TITLE
fix(aura): keep dock below chat composer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -983,7 +983,11 @@ body.aura-chat-active.keyboard-open .connectome-dock {
   opacity: 1 !important;
   pointer-events: auto !important;
   transform: translateX(-50%) !important;
-  z-index: 2301;
+  z-index: 95;
+}
+
+body.aura-chat-active.keyboard-open .connectome-dock {
+  bottom: max(14px, env(safe-area-inset-bottom, 0px)) !important;
 }
 
 body.aura-chat-active.keyboard-open .ora-container {


### PR DESCRIPTION
## Summary
- Stops the Aura chat dock override from jumping above the mobile keyboard.
- Keeps the bottom dock at the bottom safe-area while Aura chat is keyboard-open, so it does not rise into and cover the message composer/text box.
- Lowers the Aura-chat dock z-index back to shell level instead of forcing it above the chat surface.

## Verification
- npm run build
- python3 scripts/guard_no_public_secrets.py
- git diff --check

## Risk
Low/medium: CSS-only mobile keyboard behaviour. It should fix the reported overlap, but mobile Safari/Chrome keyboard viewport behaviour can vary and should be checked on-device after deploy.
