### PR TITLE
fix(feedback): keep trigger above card sheets

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1165,7 +1165,9 @@ body.aura-chat-active.keyboard-open .ora-container {
   position: fixed;
   top: calc(max(14px, env(safe-area-inset-top, 0px)) + 76px);
   right: calc(max(14px, env(safe-area-inset-right, 0px)) + 12px);
-  z-index: 2300;
+  z-index: 5000;
+  pointer-events: auto !important;
+  touch-action: manipulation;
   box-shadow: 0 14px 44px rgba(37,99,235,0.46), 0 0 0 6px rgba(5,10,24,0.38);
 }
 .connectome-feedback-btn:hover { transform: scale(1.06); box-shadow: 0 6px 18px rgba(37,99,235,0.5); }
@@ -1175,7 +1177,7 @@ body.aura-chat-active.keyboard-open .ora-container {
 .global-feedback-modal-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 2200;
+  z-index: 5100;
   background: rgba(3, 6, 20, 0.72);
   backdrop-filter: blur(12px);
   display: flex;

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import AppLauncher from './AppLauncher';
@@ -256,17 +257,23 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
       )}
 
       <button className="connectome-signout" type="button" onClick={() => { logout(); navigate('/'); }}>Sign out</button>
-      <button
-        type="button"
-        className="connectome-feedback-btn connectome-feedback-btn--floating"
-        data-feedback-widget="true"
-        aria-label="Report a bug or make a suggestion"
-        title="Report a bug or make a suggestion"
-        onClick={() => setFeedbackOpen(true)}
-      >
-        !
-      </button>
-      <GlobalFeedbackButton inlineMode inlineTrigger={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
+      {createPortal(
+        <button
+          type="button"
+          className="connectome-feedback-btn connectome-feedback-btn--floating"
+          data-feedback-widget="true"
+          aria-label="Report a bug or make a suggestion"
+          title="Report a bug or make a suggestion"
+          onClick={() => setFeedbackOpen(true)}
+        >
+          !
+        </button>,
+        document.body,
+      )}
+      {createPortal(
+        <GlobalFeedbackButton inlineMode inlineTrigger={feedbackOpen} onClose={() => setFeedbackOpen(false)} />,
+        document.body,
+      )}
       <AuraOverlay open={auraOpen} onClose={() => setAuraOpen(false)} />
       {locationPromptOpen && (
         <LocationEntryPrompt


### PR DESCRIPTION
## Summary
- portal the global feedback trigger/modal to document.body so feed card sheets cannot trap it in their stacking context
- raise feedback z-index above card/detail overlays
- force pointer/touch interaction on the floating trigger after returning from card detail

## Verification
- npm run build
- git diff --check
- light diff secret scan