### PR TITLE
fix(feed): unify Now and Future into Path

### DIFF
--- a/src/lib/AuraClient.ts
+++ b/src/lib/AuraClient.ts
@@ -352,19 +352,19 @@ class AuraClientClass {
 
   // ── Screens ───────────────────────────────────────────────────────────────
 
-  async getNextScreen(context?: string, goalId?: string, domain?: string, feedMode?: 'now' | 'future'): Promise<ScreenResponse> {
-    const res = await this.client.post('/api/screens/next', { context, goal_id: goalId, domain, feed_mode: feedMode, exclude_future_events: feedMode !== 'future' });
+  async getNextScreen(context?: string, goalId?: string, domain?: string, feedMode?: 'now' | 'future' | 'path'): Promise<ScreenResponse> {
+    const res = await this.client.post('/api/screens/next', { context, goal_id: goalId, domain, feed_mode: feedMode, exclude_future_events: false });
     return res.data as ScreenResponse;
   }
 
-  async getNextScreenBatch(count: number, goalId?: string, domain?: string, context?: string, feedMode?: 'now' | 'future'): Promise<ScreenResponse[]> {
+  async getNextScreenBatch(count: number, goalId?: string, domain?: string, context?: string, feedMode?: 'now' | 'future' | 'path'): Promise<ScreenResponse[]> {
     try {
       const body: Record<string, any> = { count: Math.min(count, 5) };
       if (goalId) body.goal_id = goalId;
       if (domain) body.domain = domain;
       if (context) body.context = context;
       if (feedMode) body.feed_mode = feedMode;
-      body.exclude_future_events = feedMode !== 'future';
+      body.exclude_future_events = false;
       const res = await this.client.post('/api/screens/batch', body);
       return res.data as ScreenResponse[];
     } catch (e: any) {
@@ -454,7 +454,7 @@ class AuraClientClass {
     return res.data as { ok: boolean; profile_updated: boolean };
   }
 
-  async submitNowCheckin(payload: { answers: Record<string, any>; goal_id?: string; feed_mode?: 'now' | 'future' }): Promise<{ ok: boolean; profile_updated: boolean; vector_mode: string }> {
+  async submitNowCheckin(payload: { answers: Record<string, any>; goal_id?: string; feed_mode?: 'now' | 'future' | 'path' }): Promise<{ ok: boolean; profile_updated: boolean; vector_mode: string }> {
     const res = await this.client.post('/api/discovery/now-checkin', payload);
     return res.data as { ok: boolean; profile_updated: boolean; vector_mode: string };
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -160,7 +160,7 @@ function App() {
           {/* AIOS app routes */}
           <Route path="/app" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
           <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
-          <Route path="/app/future" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
+          <Route path="/app/future" element={<Navigate to="/app/ido" replace />} />
           <Route path="/app/ora" element={<ShellRoute activeApp="ora"><AuraPage /></ShellRoute>} />
           <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
           <Route path="/app/routines" element={<ShellRoute activeApp="routines"><RoutinesPage /></ShellRoute>} />

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -5,7 +5,7 @@
  * backend progress signals on interaction.
  */
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { AuraClient, ScreenResponse } from '../lib/AuraClient';
 import { AuraCard } from '../components/AuraCard';
 import { CollectionPicker } from '../components/CollectionPicker';
@@ -55,7 +55,7 @@ const CAPABILITY_CARDS = [
     field: 'today_capacity',
     eyebrow: 'Capacity',
     title: 'What can you realistically do today?',
-    body: 'Now cards should fit your actual day, not an idealised version of you.',
+    body: 'Path cards should fit your actual day and future direction, not an idealised version of you.',
     options: ['5 minutes', '15–30 minutes', '1–2 hours', 'A deeper block'],
   },
   {
@@ -88,7 +88,7 @@ const CAPABILITY_CARDS = [
     field: 'desired_next_step_style',
     eyebrow: 'Next move',
     title: 'What kind of next step would help most?',
-    body: 'Aura will use this to route the Now feed across your goals, values, and nearby possibilities.',
+    body: 'Aura will use this to route your Path across your goals, values, timing, and nearby possibilities.',
     options: ['Tiny win', 'Practical progress', 'Learning/practice', 'Restore/regulate', 'Adventure/novelty', 'Service/connection'],
   },
 ];
@@ -98,7 +98,7 @@ function getDomainConfig(spec: any) {
   return DOMAIN_CONFIG[d || ''] || DEFAULT_DOMAIN;
 }
 
-type FeedMode = 'now' | 'future';
+type FeedMode = 'path';
 
 const TIME_HORIZON_OPTIONS = [
   { id: '5m', label: '5m', context: 'The user has about 5 minutes. Recommend one tiny action that can begin immediately.' },
@@ -111,12 +111,10 @@ const TIME_HORIZON_OPTIONS = [
 ] as const;
 type TimeHorizonId = typeof TIME_HORIZON_OPTIONS[number]['id'];
 
-function timeHorizonContext(mode: FeedMode, horizonId: TimeHorizonId) {
+function timeHorizonContext(_mode: FeedMode, horizonId: TimeHorizonId) {
   const horizon = TIME_HORIZON_OPTIONS.find((item) => item.id === horizonId) || TIME_HORIZON_OPTIONS[1];
-  const modeContext = mode === 'future'
-    ? 'FUTURE feed vector branch: prioritize scheduled future events, classes, programs, trips, bookings, and time-bound opportunities. Do not show generic immediate micro-actions unless they are preparation for a future event.'
-    : 'NOW feed vector branch: prioritize things the user can begin or complete right now/today. Do NOT show scheduled future events, upcoming classes, trips, or time-bound opportunities — those belong in the Future tab only. Only show actions that are immediately actionable today.';
-  return `${modeContext} Time availability: ${horizon.label}. ${horizon.context}`;
+  const pathContext = 'PATH feed vector: recommend across immediate actions, near-term steps, scheduled opportunities, future plans, goals, values, current capacity, and aligned possibilities the user has not explicitly stated as goals. Preserve temporal intelligence as metadata such as temporal_branch, urgency, and scheduled_at; do not split the experience into separate Now/Future modes.';
+  return `${pathContext} Time availability: ${horizon.label}. ${horizon.context}`;
 }
 
 
@@ -182,9 +180,8 @@ function isScheduledOpportunityCard(card: ScreenResponse | null | undefined) {
   return markers.some((marker) => text.includes(marker));
 }
 
-function enforceFeedMode(cards: ScreenResponse[], mode: FeedMode, preferredCity?: string | null) {
-  if (mode === 'future') return cards;
-  return cards.filter((card) => !isScheduledOpportunityCard(card) && !isNonLocalCard(card, preferredCity));
+function enforceFeedMode(cards: ScreenResponse[], _mode: FeedMode, preferredCity?: string | null) {
+  return cards.filter((card) => !isNonLocalCard(card, preferredCity));
 }
 
 function fallbackDeepDive(card: any, spec: any, domain: string) {
@@ -324,7 +321,7 @@ function CapabilityIntake({ goalTitle, goalId, onComplete }: { goalTitle?: strin
         CAPABILITY_CARDS.map((c) => [c.field, (nextSelected[c.id] || [])]).filter(([, value]) => Array.isArray(value) && value.length)
       );
       try {
-        await AuraClient.submitNowCheckin({ answers, goal_id: goalId, feed_mode: 'now' });
+        await AuraClient.submitNowCheckin({ answers, goal_id: goalId, feed_mode: 'path' });
       } catch {
         await Promise.allSettled(CAPABILITY_CARDS.map((c) => {
           const value = nextSelected[c.id];
@@ -374,7 +371,7 @@ function CapabilityIntake({ goalTitle, goalId, onComplete }: { goalTitle?: strin
         )}
         <div style={{ marginTop: 18, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div style={{ color: 'rgba(248,248,252,0.34)', fontSize: 12, lineHeight: 1.55 }}>
-            Aura will refresh Now around your goals, values, energy, constraints, and resources.
+            Aura will refresh your Path around your goals, values, energy, constraints, timing, and resources.
           </div>
           <button onClick={() => { sessionStorage.setItem(sessionCapabilityKey(goalId), '1'); onComplete(selected); }} style={{ background: 'transparent', border: 'none', color: 'rgba(248,248,252,0.3)', fontSize: 12, cursor: 'pointer', flexShrink: 0, marginLeft: 12 }}>
             Skip
@@ -1114,7 +1111,7 @@ function FeedCard({
 
 function _buildIntakeCard(goalTitle?: string | null, goalId?: string): any | null {
   // Build a synthetic ScreenResponse for the first capability question.
-  // This appears as card[0] in the Now feed — never blocks the feed.
+  // This appears as card[0] in the Path feed — never blocks the feed.
   const card = CAPABILITY_CARDS[0];
   if (!card) return null;
   return {
@@ -1139,7 +1136,6 @@ function _buildIntakeCard(goalTitle?: string | null, goalId?: string): any | nul
 // ─── Main feed ────────────────────────────────────────────────────────────────
 export default function FeedPage() {
   const navigate = useNavigate();
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
   React.useEffect(() => {
@@ -1152,7 +1148,7 @@ export default function FeedPage() {
   const { variant: emptyStateVariant, trackEvent: trackEmptyState } = useExperiment('feed_empty_state');
 
   const goalId = searchParams.get('goal') || undefined;
-  const requestedMode: FeedMode = location.pathname === '/app/future' ? 'future' : 'now';
+  const requestedMode: FeedMode = 'path';
   const savedTimeHorizon = (searchParams.get('time') || '30m') as TimeHorizonId;
   const initialTimeHorizon = TIME_HORIZON_OPTIONS.some((item) => item.id === savedTimeHorizon) ? savedTimeHorizon : '30m';
   const [goalTitle, setGoalTitle] = useState<string | null>(null);
@@ -1169,7 +1165,6 @@ export default function FeedPage() {
   const [hasGoals, setHasGoals] = useState<boolean | null>(null);
   const [toastMsg, setToastMsg] = useState('');
   const [collectionPickerCard, setCollectionPickerCard] = useState<any | null>(null);
-  const isFutureFeed = requestedMode === 'future';
   // Capability intake never blocks the feed — it shows as the first card inline.
   // Always start ready so the feed loads immediately.
   const [capabilityReady] = useState(true);
@@ -1202,7 +1197,7 @@ export default function FeedPage() {
     }
   }, [searchParams]);
 
-  const feedContext = `${timeHorizonContext(feedMode, timeHorizon)} ${goalId ? 'GOAL-SPECIFIC feed: optimize recommendations for the selected goal only.' : 'GENERAL NOW feed: diversify node recommendations across all active goals plus value-aligned possibilities the user has not explicitly stated as goals. Do not imply the whole Now feed is only completing one goal.'}`;
+  const feedContext = `${timeHorizonContext(feedMode, timeHorizon)} ${goalId ? 'GOAL-SPECIFIC PATH: optimize recommendations for the selected goal only while still mixing immediate, scheduled, and future-facing steps when useful.' : 'GENERAL PATH: diversify node recommendations across all active goals plus value-aligned possibilities the user has not explicitly stated as goals. Do not imply the feed is only completing one goal or only about what can happen immediately.'}`;
 
   const updateTimeHorizon = (value: TimeHorizonId) => {
     setTimeHorizon(value);
@@ -1237,9 +1232,9 @@ export default function FeedPage() {
         const single = await AuraClient.getNextScreen(feedContext, focusedGoalId, undefined, feedMode).catch(() => null);
         nextCards = enforceFeedMode(single ? [single] : [], feedMode, preferredCity);
       }
-      // Prepend context intake card for Now feed if not answered this session.
-      // The default Now feed is general; only a selected goal route passes goal context.
-      if (!isFutureFeed && !sessionStorage.getItem(sessionCapabilityKey(focusedGoalId)) && !localStorage.getItem(todayCapabilityKey(focusedGoalId))) {
+      // Prepend context intake card for Path if not answered this session.
+      // The default Path feed is general; only a selected goal route passes goal context.
+      if (!sessionStorage.getItem(sessionCapabilityKey(focusedGoalId)) && !localStorage.getItem(todayCapabilityKey(focusedGoalId))) {
         const intakeCard = _buildIntakeCard(focusedGoal?.title || goalTitle, focusedGoalId);
         if (intakeCard) nextCards = [intakeCard, ...nextCards];
       }
@@ -1268,7 +1263,7 @@ export default function FeedPage() {
   }, [capabilityReady, loadInitial]);
 
   const handleIntakeComplete = useCallback(() => {
-    showToast('Aura updated your Now vector. Refreshing cards…');
+    showToast('Aura updated your Path vector. Refreshing cards…');
     setCards([]);
     setIndex(0);
     setTimeout(() => { loadInitial(); }, 250);

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -333,7 +333,7 @@ function GoalCard({ goal, onUpdate, onDelete, onOpenFeed }: { goal: Goal; onUpda
             <div style={{ color: step ? 'rgba(248,248,252,0.78)' : 'rgba(248,248,252,0.42)', fontSize: 13, lineHeight: 1.35, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{step?.text || 'Needs Aura to turn the spark into a measurable goal'}</div>
           </div>
           <button onClick={step ? askAura : breakdown} disabled={!!busy} style={{ border: '1px solid rgba(0,212,170,0.35)', background: 'rgba(0,212,170,0.12)', color: '#00d4aa', borderRadius: 999, padding: '9px 12px', fontSize: 12, fontWeight: 900 }}>{busy ? '◈…' : step ? 'Refine' : 'Make measurable'}</button>
-          <button onClick={() => onOpenFeed(goal)} style={{ border: '1px solid rgba(139,92,246,0.35)', background: 'rgba(139,92,246,0.12)', color: '#c4b5fd', borderRadius: 999, padding: '9px 12px', fontSize: 12, fontWeight: 900 }}>Goal feed</button>
+          <button onClick={() => onOpenFeed(goal)} style={{ border: '1px solid rgba(139,92,246,0.35)', background: 'rgba(139,92,246,0.12)', color: '#c4b5fd', borderRadius: 999, padding: '9px 12px', fontSize: 12, fontWeight: 900 }}>Goal path</button>
         </div>
 
         {open && (

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -629,28 +629,28 @@ export default function ProfilePage() {
             )}
           </div>
 
-          {/* Now/Later recommendation vectors — user-modable */}
+          {/* Path recommendation vectors — user-modable */}
           <div style={{ background: '#12121a', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 14, overflow: 'hidden' }}>
             <button onClick={() => setVectorsOpen(o => !o)} style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', background: 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                 <span style={{ fontSize: 16 }}>◎</span>
                 <span style={{ fontWeight: 800, fontSize: 14, color: '#f8f8fc' }}>Recommendation vectors</span>
-                {!vectorsOpen && <span style={{ fontSize: 11, color: 'rgba(248,248,252,0.35)' }}>Now + Later</span>}
+                {!vectorsOpen && <span style={{ fontSize: 11, color: 'rgba(248,248,252,0.35)' }}>Path signals</span>}
               </div>
               <span style={{ fontSize: 14, color: 'rgba(248,248,252,0.35)', transform: vectorsOpen ? 'rotate(180deg)' : 'none' }}>▾</span>
             </button>
             {vectorsOpen && (
               <div style={{ padding: '0 16px 16px', display: 'grid', gap: 12 }}>
                 <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.45)', lineHeight: 1.55 }}>
-                  Now and Later share your values/goals, but use separate vectors. Edit these to steer what Aura recommends.
+                  Path recommendations blend your current capacity with future-facing possibilities. Edit these to steer what Aura recommends.
                 </div>
                 <label style={{ display: 'grid', gap: 6 }}>
-                  <span style={{ fontSize: 12, fontWeight: 800, color: '#00d4aa' }}>Now vector</span>
-                  <textarea value={nowVectorPrompt} onChange={(e) => setNowVectorPrompt(e.target.value)} rows={3} placeholder="What should Aura prioritise when helping me find something to do right now? Energy, time, mood, capabilities…" style={{ width: '100%', resize: 'vertical', borderRadius: 12, border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.04)', color: '#f8f8fc', padding: 12 }} />
+                  <span style={{ fontSize: 12, fontWeight: 800, color: '#00d4aa' }}>Current path signals</span>
+                  <textarea value={nowVectorPrompt} onChange={(e) => setNowVectorPrompt(e.target.value)} rows={3} placeholder="What should Aura prioritise for your current capacity? Energy, time, mood, capabilities…" style={{ width: '100%', resize: 'vertical', borderRadius: 12, border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.04)', color: '#f8f8fc', padding: 12 }} />
                 </label>
                 <label style={{ display: 'grid', gap: 6 }}>
-                  <span style={{ fontSize: 12, fontWeight: 800, color: '#a78bfa' }}>Later vector</span>
-                  <textarea value={laterVectorPrompt} onChange={(e) => setLaterVectorPrompt(e.target.value)} rows={3} placeholder="What should Aura prioritise for future/later opportunities? Events, courses, travel, big goals, aspirations…" style={{ width: '100%', resize: 'vertical', borderRadius: 12, border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.04)', color: '#f8f8fc', padding: 12 }} />
+                  <span style={{ fontSize: 12, fontWeight: 800, color: '#a78bfa' }}>Future path signals</span>
+                  <textarea value={laterVectorPrompt} onChange={(e) => setLaterVectorPrompt(e.target.value)} rows={3} placeholder="What should Aura prioritise for future-facing possibilities? Events, courses, travel, big goals, aspirations…" style={{ width: '100%', resize: 'vertical', borderRadius: 12, border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.04)', color: '#f8f8fc', padding: 12 }} />
                 </label>
                 <button onClick={saveVectorPrompts} disabled={savingVectors} style={{ background: '#8b5cf6', color: '#fff', border: 'none', borderRadius: 10, padding: '10px 12px', fontWeight: 900, cursor: savingVectors ? 'wait' : 'pointer' }}>
                   {savingVectors ? 'Saving…' : 'Save vectors ✓'}

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -17,14 +17,9 @@ interface ConnectomeShellProps {
 
 function appLabel(appId: ShellApp) {
   if (appId === 'home') return 'Aura';
-  if (appId === 'ido') return 'Now Feed';
+  if (appId === 'ido') return 'Path';
   return appById(appId)?.name || 'Aura';
 }
-
-const FEED_MODE_TABS = [
-  { id: 'now', label: 'Now', emoji: '⚡', color: '#00d4aa', path: '/app/ido' },
-  { id: 'future', label: 'Future', emoji: '🔭', color: '#8b5cf6', path: '/app/future' },
-] as const;
 
 type DockItem = {
   id: string;
@@ -35,7 +30,7 @@ type DockItem = {
 };
 
 const CORE_DOCK: DockItem[] = [
-  { id: 'ido', label: 'iDo', icon: '⚡', path: '/app/ido' },
+  { id: 'ido', label: 'Path', icon: '⚡', path: '/app/ido' },
   { id: 'ora', label: 'Aura', icon: '◈', path: '/app/ora' },
   { id: 'goals', label: 'Goals', icon: '🎯', path: '/app/goals' },
   { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },
@@ -156,16 +151,6 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
   }, [profile]);
 
   const dockItems = dockMenus[activeApp] || dockMenus.home || [];
-  const activeFeedMode = location.pathname === '/app/future' ? 'future' : 'now';
-
-  const setFeedMode = (mode: 'now' | 'future') => {
-    const next = new URLSearchParams(location.search);
-    next.delete('domain');
-    next.delete('mode');
-    const query = next.toString();
-    const basePath = mode === 'future' ? '/app/future' : '/app/ido';
-    navigate(`${basePath}${query ? `?${query}` : ''}`, { replace: true });
-  };
 
   const handleDock = (item: DockItem) => {
     if (item.action === 'aura') {
@@ -196,27 +181,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
           <span className="connectome-launcher-toggle__line" />
         </button>
 
-        {activeApp === 'ido' ? (
-          <div className="connectome-domain-switch connectome-feed-mode-switch" aria-label="Now or Future feed">
-            {FEED_MODE_TABS.map((tab) => {
-              const active = activeFeedMode === tab.id;
-              return (
-                <button
-                  key={tab.id}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => setFeedMode(tab.id)}
-                  style={active ? ({ '--domain-color': tab.color } as React.CSSProperties) : undefined}
-                  className={`connectome-domain-switch__item ${active ? 'connectome-domain-switch__item--active' : ''}`}
-                >
-                  <span aria-hidden="true">{tab.emoji}</span>{tab.label}
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <span className="connectome-context-label connectome-context-label--ambient" aria-live="polite">{appLabel(activeApp)}</span>
-        )}
+        <span className="connectome-context-label connectome-context-label--ambient" aria-live="polite">{appLabel(activeApp)}</span>
 
         <div className="connectome-status" />
       </header>
@@ -228,7 +193,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
       <nav className={`connectome-dock connectome-dock--${dockItems.length}`} aria-label={`${appLabel(activeApp)} navigation`}>
         {dockItems.map((item) => {
           const currentRoute = `${location.pathname}${location.search}`;
-          const active = item.id === activeApp || (item.path && (currentRoute === item.path || location.pathname === item.path)) || (activeApp === 'ido' && item.id === 'ido' && (location.pathname === '/app/ido' || location.pathname === '/app/future'));
+          const active = item.id === activeApp || (item.path && (currentRoute === item.path || location.pathname === item.path));
           return (
             <button
               key={item.id}


### PR DESCRIPTION
## Summary
- removes the Now/Future top switcher and makes the dock feed a single Path surface
- redirects legacy /app/future to /app/ido
- sends feed_mode=path to the backend and stops client-side blocking of scheduled/future opportunities
- updates selected-goal CTA/copy and profile vector labels to Path language

## Verification
- npm run build
- git diff --check
- python3 scripts/guard_no_public_secrets.py

## Risk
- Requires backend Path-mode PR to be deployed too; if web deploys first against old backend, feed_mode=path may be rejected by old Pydantic validation.