### PR TITLE
fix: keep mobile shell below top chrome

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,7 +30,8 @@
   --top-header-height: 56px;
   --keyboard-inset: 0px;
   --visual-viewport-height: 100dvh;
-  --shell-top-clearance: calc(var(--top-header-height) + 6px);
+  --connectome-chrome-height: var(--top-header-height);
+  --shell-top-clearance: calc(var(--connectome-chrome-height) + 6px);
   --shell-bottom-clearance: calc(72px + max(14px, env(safe-area-inset-bottom, 0px)) + 14px + var(--keyboard-inset));
 }
 
@@ -403,7 +404,7 @@ body {
   left: 0;
   right: 0;
   z-index: 90;
-  height: var(--top-header-height);
+  min-height: var(--top-header-height);
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
@@ -1013,7 +1014,7 @@ body.aura-chat-active.keyboard-open .ora-container {
 
 @media (max-width: 760px) {
   :root {
-    --shell-top-clearance: calc(var(--top-header-height) + max(18px, env(safe-area-inset-top, 0px)) + 14px);
+    --shell-top-clearance: calc(var(--connectome-chrome-height) + 14px);
   }
 
   .connectome-topbar,

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
@@ -88,6 +88,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [locationPromptOpen, setLocationPromptOpen] = useState(false);
   const [locationSyncing, setLocationSyncing] = useState(false);
+  const chromeRef = useRef<HTMLElement | null>(null);
 
   const closeApps = () => setLauncherOpen(false);
   const toggleApps = () => setLauncherOpen((open) => !open);
@@ -96,6 +97,32 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
     const openAura = () => setAuraOpen(true);
     window.addEventListener('connectome:open-aura', openAura);
     return () => window.removeEventListener('connectome:open-aura', openAura);
+  }, []);
+
+  useEffect(() => {
+    const chrome = chromeRef.current;
+    if (!chrome) return undefined;
+
+    const updateChromeHeight = () => {
+      const height = Math.ceil(Math.max(chrome.getBoundingClientRect().height, chrome.scrollHeight));
+      document.documentElement.style.setProperty('--connectome-chrome-height', `${height}px`);
+    };
+
+    updateChromeHeight();
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(updateChromeHeight)
+      : null;
+    resizeObserver?.observe(chrome);
+    window.addEventListener('resize', updateChromeHeight);
+    window.visualViewport?.addEventListener('resize', updateChromeHeight);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateChromeHeight);
+      window.visualViewport?.removeEventListener('resize', updateChromeHeight);
+      document.documentElement.style.removeProperty('--connectome-chrome-height');
+    };
   }, []);
 
   const syncLiveLocation = async () => {
@@ -167,7 +194,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
   return (
     <div className="connectome-shell">
       <div className="connectome-stars" aria-hidden="true" />
-      <header className={`connectome-ambient-chrome ${launcherOpen ? 'connectome-topbar--launcher-open' : ''}`}>
+      <header ref={chromeRef} className={`connectome-ambient-chrome ${launcherOpen ? 'connectome-topbar--launcher-open' : ''}`}>
         <button
           className={`connectome-launcher-toggle ${launcherOpen ? 'connectome-launcher-toggle--open' : ''}`}
           type="button"


### PR DESCRIPTION
## Summary\n\nPrevents the fixed Connectome mobile top chrome from overlapping page content by measuring the actual chrome height at runtime and feeding it into the shell clearance CSS variable.\n\n## Changes\n\n- Track the ambient chrome height with a ResizeObserver and viewport resize listeners.\n- Replace hard-coded shell top clearance with the measured chrome height.\n- Let the fixed chrome use min-height so safe-area/content overflow can be reflected in layout clearance.\n\n## Testing\n\n- npm run build\n- python3 scripts/guard_no_public_secrets.py\n\nFixes AvielCarlos/connectome-web#37