### PR TITLE
Add contextual Aura quick actions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -943,7 +943,8 @@ body.keyboard-open .global-feedback-fab {
 .ora-overlay__typing span { width: 7px; height: 7px; border-radius: 999px; background: #00d4aa; animation: bounce 1.2s ease-in-out infinite; }
 .ora-overlay__typing span:nth-child(2) { animation-delay: 0.15s; }
 .ora-overlay__typing span:nth-child(3) { animation-delay: 0.3s; }
-.ora-overlay__quick-actions { display: flex; gap: 8px; overflow-x: auto; padding: 0 20px 14px; }
+.ora-overlay__quick-actions { display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 20px 14px; }
+.ora-overlay__quick-context { flex: 0 0 auto; min-height: 28px; display: inline-flex; align-items: center; padding: 0 10px; border-radius: 999px; background: rgba(0,212,170,0.12); color: rgba(0,212,170,0.92); border: 1px solid rgba(0,212,170,0.18); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
 .ora-overlay__quick-actions button { flex: 0 0 auto; min-height: 38px; padding: 0 14px; border-radius: 999px; background: rgba(255,255,255,0.07); color: rgba(248,248,252,0.78); border: 1px solid rgba(255,255,255,0.08); font-size: 13px; }
 .ora-overlay__composer { display: flex; gap: 10px; padding: 16px 20px max(18px, env(safe-area-inset-bottom)); border-top: 1px solid rgba(255,255,255,0.08); }
 .ora-overlay__composer input { border-radius: 999px; background: rgba(255,255,255,0.07); }

--- a/src/shell/AuraOverlay.tsx
+++ b/src/shell/AuraOverlay.tsx
@@ -1,19 +1,78 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AuraClient, type AuraChatAction } from '../lib/AuraClient';
 
 type Message = { id: string; role: 'user' | 'ora'; content: string; actions?: AuraChatAction[] };
+type QuickAction = { label: string; prompt: string; context: string };
 
 interface AuraOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const quickActions = ['Navigate my path', "What's my IOO next step?", 'Show my life map'];
+const genericQuickActions: QuickAction[] = [
+  { label: 'Navigate my path', prompt: 'Help me choose the most aligned next step on my path.', context: 'Aura overlay' },
+  { label: "What's my IOO next step?", prompt: 'Use my IOO graph context to identify the next useful node or action.', context: 'Aura overlay' },
+  { label: 'Show my life map', prompt: 'Orient me through my current life map and the routes available from here.', context: 'Aura overlay' },
+];
+
+const pageQuickActions: { pathPrefix: string; label: string; actions: QuickAction[] }[] = [
+  {
+    pathPrefix: '/app/goals',
+    label: 'Goals page',
+    actions: [
+      { label: 'Clarify this goal', prompt: 'Use the current Goals page context to clarify the goal into outcome, constraints, and next action.', context: 'Goals page' },
+      { label: 'Find the blocker', prompt: 'Look at my current goals and identify the most likely blocker or missing support.', context: 'Goals page' },
+      { label: 'Make a 7-day path', prompt: 'Turn the most relevant goal here into a practical 7-day path with one small action per day.', context: 'Goals page' },
+    ],
+  },
+  {
+    pathPrefix: '/app/ido',
+    label: 'Path Feed page',
+    actions: [
+      { label: 'Why this card?', prompt: 'Explain why the current Path Feed card may be appearing and what signal it is testing.', context: 'Path Feed page' },
+      { label: 'Choose or skip?', prompt: 'Help me decide whether to act on, save, or skip the current feed card.', context: 'Path Feed page' },
+      { label: 'Tune my feed', prompt: 'Ask me one useful question that would make this feed more aligned.', context: 'Path Feed page' },
+    ],
+  },
+  {
+    pathPrefix: '/app/ioo',
+    label: 'Path Map page',
+    actions: [
+      { label: 'Explain this route', prompt: 'Explain the Path Map route I am viewing in plain language and identify the next node.', context: 'Path Map page' },
+      { label: 'Find bridge nodes', prompt: 'Suggest bridge nodes that could connect my current state to the outcome I want.', context: 'Path Map page' },
+      { label: 'Show prerequisites', prompt: 'Identify likely hidden prerequisites before I can progress on this path.', context: 'Path Map page' },
+    ],
+  },
+  {
+    pathPrefix: '/app/dao',
+    label: 'DAO page',
+    actions: [
+      { label: 'Explain CP', prompt: 'Explain how CP, governance, and contribution reputation apply to what I am viewing.', context: 'DAO page' },
+      { label: 'Find a contribution', prompt: 'Suggest one concrete contribution I could make from this DAO context.', context: 'DAO page' },
+      { label: 'Assess proposal fit', prompt: 'Help me assess whether this proposal fits the ecosystem mission and current priorities.', context: 'DAO page' },
+    ],
+  },
+  {
+    pathPrefix: '/app/contribute',
+    label: 'Contribute page',
+    actions: [
+      { label: 'Shape submission', prompt: 'Help me turn this contribution idea into a clear, reviewable submission.', context: 'Contribute page' },
+      { label: 'Estimate CP signals', prompt: 'Estimate the CP-relevant value signals for this contribution and what evidence to include.', context: 'Contribute page' },
+      { label: 'Find useful work', prompt: 'Suggest the most useful small contribution I could make from here.', context: 'Contribute page' },
+    ],
+  },
+];
+
+function quickActionConfig(pathname: string) {
+  const pageConfig = pageQuickActions.find((entry) => pathname.startsWith(entry.pathPrefix));
+  return pageConfig ?? { label: 'Aura overlay', actions: genericQuickActions };
+}
 
 export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
   const location = useLocation();
-  const quickActionContext = location.pathname.startsWith('/app/goals') ? 'Goals page' : location.pathname.startsWith('/app/ido') ? 'Path Feed page' : 'Aura overlay';
+  const quickActions = useMemo(() => quickActionConfig(location.pathname), [location.pathname]);
+  const quickActionContext = quickActions.label;
   const [messages, setMessages] = useState<Message[]>([
     {
       id: 'opening',
@@ -164,9 +223,17 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
           <div ref={endRef} />
         </div>
 
-        <div className="ora-overlay__quick-actions">
-          {quickActions.map((action) => (
-            <button key={action} type="button" onClick={() => sendMessage(action)}>{action}</button>
+        <div className="ora-overlay__quick-actions" aria-label={`${quickActionContext} quick actions`}>
+          <span className="ora-overlay__quick-context">{quickActionContext}</span>
+          {quickActions.actions.map((action) => (
+            <button
+              key={`${action.context}:${action.label}`}
+              type="button"
+              title={action.context}
+              onClick={() => sendMessage(`[${action.context}] ${action.prompt}`)}
+            >
+              {action.label}
+            </button>
           ))}
         </div>
 


### PR DESCRIPTION
## Summary
- refreshes the Aura overlay quick actions on top of current `main` after the newer Aura app-context/action-chip work
- adds typed, route-aware quick actions for Goals, Path Feed, Path Map, DAO, and Contribute surfaces
- sends selected quick actions as page-contextual prompts while preserving backend app-context payloads and suggested action chips
- adds a small context pill so users can see which app surface Aura is acting from

## Validation
- npm run build
- git diff --check
- python3 scripts/guard_no_public_secrets.py

Do not merge until Avi approves.

Fixes AvielCarlos/connectome-web#16
