### PR TITLE
Prefetch a deeper Path Feed queue

### DIFF
--- a/src/lib/AuraClient.ts
+++ b/src/lib/AuraClient.ts
@@ -366,7 +366,7 @@ class AuraClientClass {
 
   async getNextScreenBatch(count: number, goalId?: string, domain?: string, context?: string, feedMode?: 'now' | 'future' | 'path'): Promise<ScreenResponse[]> {
     try {
-      const body: Record<string, any> = { count: Math.min(count, 5) };
+      const body: Record<string, any> = { count: Math.min(Math.max(count, 1), 20) };
       if (goalId) body.goal_id = goalId;
       if (domain) body.domain = domain;
       if (context) body.context = context;

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1133,6 +1133,10 @@ function _buildIntakeCard(goalTitle?: string | null, goalId?: string): any | nul
   };
 }
 
+const FEED_INITIAL_PREFETCH_COUNT = 12;
+const FEED_LOAD_MORE_COUNT = 8;
+const FEED_PREFETCH_THRESHOLD = 5;
+
 // ─── Main feed ────────────────────────────────────────────────────────────────
 export default function FeedPage() {
   const navigate = useNavigate();
@@ -1226,7 +1230,7 @@ export default function FeedPage() {
       if (focusedGoal?.title) setGoalTitle(focusedGoal.title);
       else if (!goalId) setGoalTitle(null);
       const focusedGoalId = goalId ? focusedGoal?.id : undefined;
-      const batch = await AuraClient.getNextScreenBatch(5, focusedGoalId, undefined, feedContext, feedMode);
+      const batch = await AuraClient.getNextScreenBatch(FEED_INITIAL_PREFETCH_COUNT, focusedGoalId, undefined, feedContext, feedMode);
       let nextCards = enforceFeedMode(batch, feedMode, preferredCity);
       if (!nextCards.length) {
         const single = await AuraClient.getNextScreen(feedContext, focusedGoalId, undefined, feedMode).catch(() => null);
@@ -1294,7 +1298,7 @@ export default function FeedPage() {
     if (loadingMore || isLimited) return;
     setLoadingMore(true);
     try {
-      const batch = await AuraClient.getNextScreenBatch(3, goalId, undefined, feedContext, feedMode);
+      const batch = await AuraClient.getNextScreenBatch(FEED_LOAD_MORE_COUNT, goalId, undefined, feedContext, feedMode);
       let nextCards = enforceFeedMode(batch, feedMode, preferredCity);
       if (!nextCards.length) {
         const single = await AuraClient.getNextScreen(feedContext, goalId, undefined, feedMode).catch(() => null);
@@ -1322,7 +1326,7 @@ export default function FeedPage() {
     setIndex((prev) => {
       const next = Math.min(prev + 1, cards.length - 1);
       scrollToIndex(next);
-      if (next >= cards.length - 2) loadMore();
+      if (next >= cards.length - FEED_PREFETCH_THRESHOLD) loadMore();
       return next;
     });
   }, [cards.length, scrollToIndex, loadMore]);
@@ -1605,7 +1609,7 @@ export default function FeedPage() {
           const newIndex = Math.round(el.scrollTop / el.clientHeight);
           if (newIndex !== index) {
             setIndex(newIndex);
-            if (newIndex >= cards.length - 2) loadMore();
+            if (newIndex >= cards.length - FEED_PREFETCH_THRESHOLD) loadMore();
           }
         }}
       >


### PR DESCRIPTION
## Summary
- load 12 feed cards up front instead of 5
- append 8 more cards at a time instead of 3
- start fetching earlier when the user is within 5 cards of the queue end
- allow the client to request up to 20 batched screens for TikTok-style always-ready scrolling

## Validation
- npm run build
- git diff --check
- python3 scripts/guard_no_public_secrets.py

Do not merge until Avi approves.