### PR TITLE
Move feedback button to top right

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1164,7 +1164,7 @@ body.aura-chat-active.keyboard-open .ora-container {
 }
 .connectome-feedback-btn--floating {
   position: fixed;
-  top: calc(max(14px, env(safe-area-inset-top, 0px)) + 76px);
+  top: calc(max(14px, env(safe-area-inset-top, 0px)) + 8px);
   right: calc(max(14px, env(safe-area-inset-right, 0px)) + 12px);
   z-index: 5000;
   pointer-events: auto !important;


### PR DESCRIPTION
## Summary
- moves the universal  feedback trigger from below the header area to the top-right safe-area position
- keeps the existing fixed portal trigger, z-index, and modal behaviour unchanged

## Validation
- npm run build
- git diff --check
- python3 scripts/guard_no_public_secrets.py

Do not merge until Avi approves.