### PR TITLE
Show consistent DAO CP totals

### DIFF
--- a/src/pages/DAOPage.tsx
+++ b/src/pages/DAOPage.tsx
@@ -486,7 +486,14 @@ export default function DAOPage() {
   const [toast, setToast] = useState('');
   const isLoggedIn = authStorage.isAuthenticated();
 
-  const cpBalance = profile?.total_dao_cp ?? profile?.contributor?.cp_balance ?? 0;
+  const cpBalance = Number(
+    profile?.total_dao_cp
+    ?? profile?.profile?.total_dao_cp
+    ?? profile?.cp_balance
+    ?? profile?.profile?.cp_balance
+    ?? profile?.contributor?.cp_balance
+    ?? 0
+  );
 
   useEffect(() => {
     Promise.all([


### PR DESCRIPTION
## Summary\n- makes the DAO status card read CP totals from the same profile fields used elsewhere\n- falls back across top-level and nested profile CP fields so stale API shape differences do not show 0/wrong CP\n\n## Validation\n- npm run build\n- git diff --check\n- python3 scripts/guard_no_public_secrets.py\n\nDo not merge until Avi approves.