### PR TITLE
fix: prevent mobile shell header overlap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,7 @@
   --keyboard-inset: 0px;
   --visual-viewport-height: 100dvh;
   --connectome-chrome-height: var(--top-header-height);
-  --shell-top-clearance: calc(var(--connectome-chrome-height) + 6px);
+  --shell-top-clearance: calc(var(--connectome-chrome-height) + 12px);
   --shell-bottom-clearance: calc(72px + max(14px, env(safe-area-inset-bottom, 0px)) + 14px + var(--keyboard-inset));
 }
 
@@ -422,6 +422,22 @@ body {
 .connectome-ambient-chrome {
   pointer-events: none;
   background: linear-gradient(180deg, rgba(6, 6, 16, 0.34), transparent);
+}
+
+@media (max-width: 420px) {
+  .connectome-ambient-chrome {
+    grid-template-columns: 44px minmax(0, 1fr) 44px;
+    gap: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .connectome-context-label {
+    max-width: 46vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .connectome-ambient-chrome > * {

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -105,7 +105,9 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
 
     const updateChromeHeight = () => {
       const height = Math.ceil(Math.max(chrome.getBoundingClientRect().height, chrome.scrollHeight));
+      const clearance = height + 12;
       document.documentElement.style.setProperty('--connectome-chrome-height', `${height}px`);
+      document.documentElement.style.setProperty('--shell-top-clearance', `${clearance}px`);
     };
 
     updateChromeHeight();
@@ -122,6 +124,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
       window.removeEventListener('resize', updateChromeHeight);
       window.visualViewport?.removeEventListener('resize', updateChromeHeight);
       document.documentElement.style.removeProperty('--connectome-chrome-height');
+      document.documentElement.style.removeProperty('--shell-top-clearance');
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Measure the fixed Connectome chrome and publish an explicit shell top clearance with a 12px breathing gap.
- Increase the CSS fallback clearance so first paint has safer spacing before measurement runs.
- Constrain the ambient context label on very narrow phones so the top bar does not crowd the shell.

## Testing
- npm run build
- python3 scripts/guard_no_public_secrets.py

Fixes #37