### PR TITLE
chore(rename): full Ora → Aura sweep (frontend Wave 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Connectome Web
 
 Ecosystem map:
 
-- **Ora** — the AI brain and agent layer.
+- **Aura** — the AI brain and agent layer.
 - **Connectome** — the AI OS / nervous system.
 - **iDo** — the daily app experience.
 - **Ascension Technologies** — DAO, CP, governance, and contributor ownership layer.

--- a/docs/DEVELOPER_MISSION.md
+++ b/docs/DEVELOPER_MISSION.md
@@ -1,10 +1,10 @@
 # Developer Mission — Design the Interface for an AI OS
 
-Connectome Web is the human surface of the Ascension Technologies ecosystem. It turns the Ora brain and Connectome nervous system into a daily product people can use to act, reflect, discover, contribute, and coordinate.
+Connectome Web is the human surface of the Ascension Technologies ecosystem. It turns the Aura brain and Connectome nervous system into a daily product people can use to act, reflect, discover, contribute, and coordinate.
 
 The ecosystem has four layers:
 
-- **Ora** — the AI brain: agents that understand goals, context, constraints, opportunities, and feedback.
+- **Aura** — the AI brain: agents that understand goals, context, constraints, opportunities, and feedback.
 - **Connectome** — the nervous system: APIs, graph intelligence, memory, execution protocol, and integrations.
 - **iDo** — the daily surface: a WeChat-like app for action, discovery, routines, services, and community.
 - **Ascension Technologies** — the DAO/governance layer: CP, recognition, stewardship, and eventual economic coordination.
@@ -13,7 +13,7 @@ The ecosystem has four layers:
 
 High-leverage frontend work includes:
 
-- Contextual Ora quick actions that make each page feel agent-aware.
+- Contextual Aura quick actions that make each page feel agent-aware.
 - Shared design primitives that make the app faster to extend.
 - IOO execution views that show agent progress, options, and decisions clearly.
 - Contribution and CP surfaces that help developers understand the path from shipped work to recognition.
@@ -26,7 +26,7 @@ Agentic AI will only matter if people can trust it, understand it, and integrate
 
 Good Connectome Web work helps users:
 
-- understand what Ora can do,
+- understand what Aura can do,
 - choose meaningful next actions,
 - see progress without cognitive overload,
 - contribute to the ecosystem,

--- a/docs/ONTOLOGY.md
+++ b/docs/ONTOLOGY.md
@@ -16,7 +16,7 @@ and the system drifts. This document anchors the language.
 Three rules:
 
 1. Every concept here has one meaning. If you need a new concept, add it; do not overload an existing one.
-2. Boundaries matter. iDo is not Connectome. DAO is not iDo. Ora is not the OS.
+2. Boundaries matter. iDo is not Connectome. DAO is not iDo. Aura is not the OS.
 3. Whenever something visible to users changes, ask: *what entity, relationship, layer, app, agent, permission, and feedback signal does this touch?*
 
 ---
@@ -34,7 +34,7 @@ Three rules:
 - Backend: Railway / FastAPI / Postgres / vector store.
 - Frontend: AIOS shell (web today; mobile/native later).
 
-### Ora — Intelligence
+### Aura — Intelligence
 - The agentic mind that runs through Connectome.
 - Reasons across goals, constraints, memory, IOO Graph, signals.
 - Surfaces: chat overlay, recommendations, attention layer, generated tools, agents.
@@ -43,7 +43,7 @@ Three rules:
 ### IOO Graph — Map of human possibility
 - Semantic graph of goals, needs, constraints, opportunities, skills, routines, missions, transformation paths.
 - The "file system" of Connectome.
-- Used by Ora to decide *what should this person do next*.
+- Used by Aura to decide *what should this person do next*.
 
 ### Apps — Surfaces
 - iDo, iVive, Eviva, Aventi, DAO, plus shared surfaces (Goals, Routines, Services, IOO Map, Profile).
@@ -56,7 +56,7 @@ Three rules:
 - Sovereign over their data and permissions.
 
 ### Agents — Background processes
-- Ora-spawned or scheduled processes that act on entities.
+- Aura-spawned or scheduled processes that act on entities.
 - Examples: outreach, growth, enrichment, executive council, IOO graph builder, experiment generator.
 - Bound by permissions, safety levels, and the DAO governance layer.
 
@@ -81,13 +81,13 @@ Each entity has: name · purpose · key fields · lifecycle · who can create/re
 - **Community** — group context (DAO, guild, circle). fields: kind, scope, membership policy.
 - **DAO Task** — a contributable unit of work in Ascension. fields: kind (code, content, ops, outreach, governance), CP_reward, gating.
 - **Health Signal** — vitality/biometric/state input. fields: source, kind, value, time, confidence.
-- **Memory** — user-visible learning/recall record. Framing is A/B tested as “Ora remembers...” vs “saved to your profile/OS memory.” fields: kind (fact, preference, story, lesson), salience, privacy_tier.
+- **Memory** — user-visible learning/recall record. Framing is A/B tested as “Aura remembers...” vs “saved to your profile/OS memory.” fields: kind (fact, preference, story, lesson), salience, privacy_tier.
 - **Agent** — background process. fields: id, role, schedule, scope, permissions, fitness, lineage.
 - **App** — a visible surface inside the AIOS. fields: id, domain, dock, permissions, manifest.
 - **Permission** — granted access to a domain. fields: domain (memory/calendar/location/health/social/dao/files/notifications), scope, expires_at.
 - **Feedback Event** — anything users do that updates models. fields: kind (view, save, skip, complete, rate, abandon, react), target, value, context.
 - **Experiment** — a live test. fields: name, variants, allocation, fitness_function, lineage, status.
-- **Recommendation** — Ora's surfaced suggestion. fields: target_entity, reason, confidence, expires_at.
+- **Recommendation** — Aura's surfaced suggestion. fields: target_entity, reason, confidence, expires_at.
 - **Notification** — attention-layer message. fields: trigger, app, urgency, channel, time_window.
 - **Achievement / Milestone** — meaningful progress markers. fields: kind, evidence, awarded_at.
 
@@ -113,7 +113,7 @@ Examples (canonical predicates):
 - iVive **unlocks_readiness_for** Eviva (prerequisite gating)
 - DAO **governs** Connectome
 - Connectome **hosts** App
-- Ora **recommends** Goal | Routine | Mission | Event | Service | Action
+- Aura **recommends** Goal | Routine | Mission | Event | Service | Action
 - Feed **renders** Opportunity | Event | Mission | Routine | Service
 - iDo Feed **blends** iVive Feed | Eviva Feed | Aventi Feed | DAO/Contribute Signals
 
@@ -127,7 +127,7 @@ Examples (canonical predicates):
 
 Rest is an **aspect of iVive**, not a separate domain. It surfaces through recovery/sleep optimization, biometrics-driven rest nudges, nervous-system regulation, and practical tools like Pomodoro/rest timers — all inside iVive.
 
-iVive ↔ Eviva gating: Eviva opportunities can require iVive readiness; Ora spawns the bridge nodes.
+iVive ↔ Eviva gating: Eviva opportunities can require iVive readiness; Aura spawns the bridge nodes.
 
 ---
 
@@ -136,7 +136,7 @@ iVive ↔ Eviva gating: Eviva opportunities can require iVive readiness; Ora spa
 ### Daily life cluster
 - **iDo** — daily life surface. Feed, goals, routines, and the core decision mentality: **delegate it, plan it, or ditch it**.
 - **Goals** and **Routines** — primarily iDo features. They also generate shared datapoints for other apps/interfaces.
-- **Journal is scrapped as a primary app/surface.** Reflection may still exist as background memory capture or an Ora conversation mode, but the product mentality is action-oriented: delegate it, plan it, or ditch it.
+- **Journal is scrapped as a primary app/surface.** Reflection may still exist as background memory capture or an Aura conversation mode, but the product mentality is action-oriented: delegate it, plan it, or ditch it.
 
 ### Domain apps
 - **iVive** — vitality OS, including sleep, recovery, and rest as first-class aspects.
@@ -145,7 +145,7 @@ iVive ↔ Eviva gating: Eviva opportunities can require iVive readiness; Ora spa
 
 ### System apps
 - **DAO** — governance, contribution, CP/XP economics.
-- **Services** — tools, integrations, Ora-generated surfaces.
+- **Services** — tools, integrations, Aura-generated surfaces.
 - **IOO Map** — explorable view of the graph.
 - **Profile** — single identity/permissions/sovereignty/stats app opened from the top-right corner across the AIOS.
 
@@ -188,7 +188,7 @@ Safe-auto vs human-approved is defined per change kind (copy, weights, ranking �
 
 ## 8. Visible vs invisible language
 
-- **User-facing**: Ora, iDo, iVive, Eviva, Aventi, DAO, Goals, Routines, Profile.
+- **User-facing**: Aura, iDo, iVive, Eviva, Aventi, DAO, Goals, Routines, Profile.
 - **Architectural / internal / mission**: Connectome, IOO Graph, Agents, AIOS. Use Connectome silently for the most part; name it only when required to make the system make sense.
 - **DAO / community-facing**: Ascension Technologies, CP, XP, Eviva Universal.
 
@@ -220,7 +220,7 @@ Aventi is a domain of human activity and an external app we are developing. It r
 Journal is scrapped as a primary app. The iDo mentality is **delegate it, plan it, or ditch it**. Goals and Routines are primarily iDo features, but they provide shared datapoints for other interfaces/apps.
 
 ### C. Feed ownership — DECIDED
-The feed uses a **hybrid model**. Each domain can mature into its own feed/surface (iVive, Eviva, Aventi), while iDo renders the blended “What should I do next?” meta-feed. Ontologically: the attention engine belongs to Ora/Connectome infrastructure; the visible daily feed belongs to iDo.
+The feed uses a **hybrid model**. Each domain can mature into its own feed/surface (iVive, Eviva, Aventi), while iDo renders the blended “What should I do next?” meta-feed. Ontologically: the attention engine belongs to Aura/Connectome infrastructure; the visible daily feed belongs to iDo.
 
 ### D. DAO / Contribute / Eviva overlap — DECIDED
 Keep **DAO**, **Contribute**, and **Eviva** separate:
@@ -242,7 +242,7 @@ Rest belongs inside iVive as a first-class aspect, not as a fourth domain. It su
 
 ### H. Memory framing — DECIDED AS EXPERIMENT
 A/B test memory framing:
-- “Ora remembers...”
+- “Aura remembers...”
 - “Saved to your profile / OS memory...”
 Use different framing by context and measure trust/resonance.
 
@@ -260,7 +260,7 @@ Model individual people first. Future linking supports partners, family, friends
 
 ## 2026-04-30 Alignment Update
 
-- Public/user-facing intelligence brand: **Aura**. Legacy `Ora` can remain in code/API/storage compatibility surfaces until intentionally migrated.
+- Public/user-facing intelligence brand: **Aura**. Legacy `Aura` can remain in code/API/storage compatibility surfaces until intentionally migrated.
 - Main ordinary-user brand: **Aura**. **Connectome** may be visible, but should not dominate ordinary app chrome; it is primarily the orchestration AIOS underneath.
 - **iDo** currently names the Path Feed, but can evolve into a broader fulfilment interface set or full life AIOS if that tests/systematizes best.
 - **IOO** is internal language. Users see Path Maps / Life Maps / tested front-end language.

--- a/docs/UX_FLOW.md
+++ b/docs/UX_FLOW.md
@@ -12,14 +12,14 @@ Public site (`web/atdao`) is the Ascension/DAO front door. GitHub Pages `connect
 
 ## Screen Graph principle
 
-Connectome screens are not fixed destinations. A generated screen is a pathway node: a temporary interface between the user's current state, Ora's IOO possibility graph, and the execution layer.
+Connectome screens are not fixed destinations. A generated screen is a pathway node: a temporary interface between the user's current state, Aura's IOO possibility graph, and the execution layer.
 
 This means UI work should assume:
 
 - a page/card can clarify intent, route to another card, execute an action, or belong to an IOO node;
-- screens should preserve enough metadata for Ora to learn why they were shown;
+- screens should preserve enough metadata for Aura to learn why they were shown;
 - transitions matter as much as the screen itself — what the screen leads to, requires, clarifies, or executes is part of the product;
-- multiple possible paths can exist from point A to point B, and Ora may rank or reroute them over time.
+- multiple possible paths can exist from point A to point B, and Aura may rank or reroute them over time.
 
 Apps/domains such as **iVive**, **Eviva**, and **Aventi** are reusable modules/modes used by Aura to guide the user. They should bend around the user's path rather than behave like isolated apps with hard walls.
 
@@ -81,7 +81,7 @@ The purpose is not app navigation. The purpose is helping people fulfil their de
 
 ## Screen Pattern Library principle
 
-Reusable screen patterns should behave like living UI memory, not a pile of templates. Ora can create or reuse a pattern, test small variants, reinforce the winners, and trim patterns that are stale, unused, or low-outcome.
+Reusable screen patterns should behave like living UI memory, not a pile of templates. Aura can create or reuse a pattern, test small variants, reinforce the winners, and trim patterns that are stale, unused, or low-outcome.
 
 Foundational lifecycle:
 
@@ -90,7 +90,7 @@ Foundational lifecycle:
 - **Reinforce winners** when users reach clarity, completion, execution, or other positive outcomes.
 - **Trim stale/unused/low-outcome patterns** so the library stays sharp and does not keep resurfacing weak experiences.
 
-Pattern metadata should preserve enough lifecycle signal for pruning: `last_used_at`, `usage_count`, `success_score` / `outcome_score`, and deprecated/pruned state. Prefer soft-pruning over deletion so Ora can retain historical learning while avoiding reuse.
+Pattern metadata should preserve enough lifecycle signal for pruning: `last_used_at`, `usage_count`, `success_score` / `outcome_score`, and deprecated/pruned state. Prefer soft-pruning over deletion so Aura can retain historical learning while avoiding reuse.
 
 Primary feed responses are graph-learning signals:
 
@@ -115,7 +115,7 @@ Primary feed responses are graph-learning signals:
 ### 1. First-time visitor → sign up → onboarding → home/feed
 
 1. Public entry explains Ascension/Connectome/iDo at a high level.
-2. User opens app and sees auth page: “iDo — your daily AI life app, guided by Ora.”
+2. User opens app and sees auth page: “iDo — your daily AI life app, guided by Aura.”
 3. Registration goes to `/onboarding` when the onboarding experiment asks for it; otherwise it lands at `/app`.
 4. Onboarding collects orientation signals.
 5. Completion lands at `/app`.
@@ -126,7 +126,7 @@ Primary feed responses are graph-learning signals:
 ### 2. Returning user → home → choose goal/discovery → feed/action
 
 1. Login, OAuth callback, `/`, and `/app` land on the Connectome home/orientation screen.
-2. If the user has intent, Goals opens focused and invites them to clarify with Ora.
+2. If the user has intent, Goals opens focused and invites them to clarify with Aura.
 3. If the user lacks intent, iDo opens the one-action feed.
 4. Feed cards support save/rate/skip/detail and should embed goal-building or external-app context as IOO Nodes/pathway sheets before routing to another app.
 
@@ -159,13 +159,13 @@ Primary feed responses are graph-learning signals:
 - `/` — unauthenticated auth page; authenticated Connectome/iDo home.
 - `/auth/callback` — Google OAuth callback; stores auth and redirects to `/app`.
 - `/auth/github-callback` — GitHub connection callback; redirects to `/app/contribute?github=connected`.
-- `/onboarding` — authenticated Ora onboarding; completion redirects to `/app`.
+- `/onboarding` — authenticated Aura onboarding; completion redirects to `/app`.
 
 ### Authenticated app
 
 - `/app` — Home/orientation screen.
 - `/app/ido` — one-action feed/discovery.
-- `/app/goals` — goals and Ora clarification.
+- `/app/goals` — goals and Aura clarification.
 - `/app/routines` — routines and habits.
 - `/app/dao` — DAO, CP, proposals, governance, contribution overview.
 - `/app/contribute` — submit contributions and sync GitHub.
@@ -186,30 +186,30 @@ Primary feed responses are graph-learning signals:
 - `/contribute` → `/app/contribute`
 - `/services` → `/app/services`
 - `/profile` → `/app/profile`
-- `/ora` → `/app`
+- `/aura` (legacy `/ora`) → `/app`
 
 ## Screen purposes, first 5 seconds, CTAs
 
 | Screen | Purpose | Must answer in 5 seconds | Primary CTA | Secondary CTA |
 |---|---|---|---|---|
-| Auth | Sign in/up to iDo/Ora | “This is my daily AI life app.” | Continue with Google / Sign in | Register |
-| `/app` Home | Orient the user and route intent | “Choose goal clarification or discovery.” | Clarify with Ora | Open iDo feed |
+| Auth | Sign in/up to iDo/Aura | “This is my daily AI life app.” | Continue with Google / Sign in | Register |
+| `/app` Home | Orient the user and route intent | “Choose goal clarification or discovery.” | Clarify with Aura | Open iDo feed |
 | `/app/ido` | Present one next action | “Here is something I can do now.” | Act/save/rate card | Skip / make it a goal |
-| `/app/goals` | Convert intent into structured path | “Tell Ora what you want.” | Start clarification | Pick a starter |
+| `/app/goals` | Convert intent into structured path | “Tell Aura what you want.” | Start clarification | Pick a starter |
 | `/app/dao` | Explain contribution economy/governance | “This is how the ecosystem is governed and rewarded.” | Open Contribute | Browse issues/proposals |
 | `/app/contribute` | Submit evidence of work | “Submit concrete work and earn CP.” | Submit contribution | Connect GitHub / What is CP? |
 | `/app/profile` | Identity, settings, system/admin | “This is my account and controls.” | Manage profile/settings | Open admin/system sections |
-| `/app/services` | Tools and surfaces | “Use or generate Ora-powered tools.” | Open tool/surface | Ask Ora |
-| `/app/ioo` | Semantic map | “This is Ora’s life graph.” | Explore map | Return to goals/iDo |
-| `/app/ivive` | Vitality domain | “Improve energy/body/mind.” | Start vitality action | Ask Ora |
+| `/app/services` | Tools and surfaces | “Use or generate Aura-powered tools.” | Open tool/surface | Ask Aura |
+| `/app/ioo` | Semantic map | “This is Aura’s life graph.” | Explore map | Return to goals/iDo |
+| `/app/ivive` | Vitality domain | “Improve energy/body/mind.” | Start vitality action | Ask Aura |
 | `/app/eviva` | Mission/service domain | “Find meaningful contribution.” | Explore missions/services | Contribute |
 
 ## Navigation rules
 
 - **Home is the orientation hub**: `/` when authenticated and `/app` both render it.
-- **Dock is local navigation**: show the 4–5 most relevant neighbouring actions for the current app. Keep Ora centered/contextual where possible.
+- **Dock is local navigation**: show the 4–5 most relevant neighbouring actions for the current app. Keep Aura centered/contextual where possible.
 - **Launcher is global navigation**: hamburger opens all major surfaces using user-outcome labels, not internal architecture labels.
-- **Ora overlay is contextual assistance**: use for questions, clarification, and routing help; do not make it the only way to move between screens.
+- **Aura overlay is contextual assistance**: use for questions, clarification, and routing help; do not make it the only way to move between screens.
 - **Profile is identity/settings**: admin/dev/system tools may live there for now but should not be primary user navigation.
 - **Legacy routes redirect** rather than render duplicate screens.
 
@@ -218,8 +218,8 @@ Primary feed responses are graph-learning signals:
 - **Auth**: show backend error; return to auth page after callback failure.
 - **Onboarding**: if already complete, redirect to `/app`; if API fails, avoid trapping user in a blank shell.
 - **Home**: static orientation should render without API dependency.
-- **Feed**: loading should communicate that Ora is preparing actions; empty should offer goals and feedback.
-- **Goals**: skeleton while loading; empty state invites starter or typed goal; failed Ora clarification should show toast.
+- **Feed**: loading should communicate that Aura is preparing actions; empty should offer goals and feedback.
+- **Goals**: skeleton while loading; empty state invites starter or typed goal; failed Aura clarification should show toast.
 - **DAO**: empty leaderboard/proposals explain what to do next, not just “none.”
 - **Contribute**: unauthenticated submit disabled with sign-in copy; code contribution requires GitHub; success/error messages stay inline.
 - **Feedback**: screenshot capture is optional; failed submit shows retryable error.

--- a/src/components/AuraCard.tsx
+++ b/src/components/AuraCard.tsx
@@ -498,7 +498,7 @@ export function AuraCard({ component: comp, index, onAction }: AuraCardProps) {
           padding: 16,
           marginBottom: 12,
         }}>
-          {comp.ora_note && (
+          {comp.aura_note && (
             <div style={{
               display: 'flex',
               gap: 8,
@@ -509,7 +509,7 @@ export function AuraCard({ component: comp, index, onAction }: AuraCardProps) {
             }}>
               <span style={{ color: '#00d4aa', fontSize: 11 }}>✦</span>
               <span style={{ color: 'rgba(248,248,252,0.6)', fontSize: 12, fontStyle: 'italic', lineHeight: 1.5 }}>
-                {comp.ora_note}
+                {comp.aura_note}
               </span>
             </div>
           )}
@@ -705,7 +705,7 @@ export function AuraCard({ component: comp, index, onAction }: AuraCardProps) {
           </div>
           <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 4, lineHeight: 1.4 }}>{comp.title}</div>
           {comp.channel && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.5)', marginBottom: 8 }}>{comp.channel}</div>}
-          {comp.ora_note && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.55)', fontStyle: 'italic', marginBottom: 10, lineHeight: 1.5 }}>{comp.ora_note}</div>}
+          {comp.aura_note && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.55)', fontStyle: 'italic', marginBottom: 10, lineHeight: 1.5 }}>{comp.aura_note}</div>}
           {comp.youtube_url && (
             <a href={comp.youtube_url} target="_blank" rel="noopener noreferrer" style={{
               display: 'block',

--- a/src/components/AuraOnboarding.tsx
+++ b/src/components/AuraOnboarding.tsx
@@ -10,7 +10,7 @@ const TOTAL_QUESTIONS = 6;
 const ONBOARDING_CACHE_KEY = 'onboarding_done';
 
 function Bubble({ message }: { message: ChatMessage }) {
-  const isAura = message.role === 'ora';
+  const isAura = message.role === 'aura';
   return (
     <div style={{ display: 'flex', flexDirection: isAura ? 'row' : 'row-reverse', gap: 10, marginBottom: 12, alignItems: 'flex-end' }}>
       {isAura && (
@@ -99,7 +99,7 @@ export default function AuraOnboarding() {
         setLoading(true);
         const res = await AuraClient.advanceOnboarding([]);
         if (cancelled) return;
-        setMessages([{ id: 'opening', role: 'ora', content: res.message }]);
+        setMessages([{ id: 'opening', role: 'aura', content: res.message }]);
         setQuestionIndex(res.question_index);
         setTotalQuestions(res.total_questions || TOTAL_QUESTIONS);
         setVariantId(res.variant_id || status.variant_id || null);
@@ -134,7 +134,7 @@ export default function AuraOnboarding() {
     try {
       const conversation = nextMessages.map(({ role, content }) => ({ role, content }));
       const res = await AuraClient.advanceOnboarding(conversation);
-      setMessages(prev => [...prev, { id: `${Date.now()}-ora`, role: 'ora', content: res.message }]);
+      setMessages(prev => [...prev, { id: `${Date.now()}-aura`, role: 'aura', content: res.message }]);
       setQuestionIndex(Math.min(res.question_index, res.total_questions - 1));
       setTotalQuestions(res.total_questions || TOTAL_QUESTIONS);
       setVariantId(res.variant_id || variantId);
@@ -148,7 +148,7 @@ export default function AuraOnboarding() {
       console.error('Onboarding send failed:', e);
       setMessages(prev => [...prev, {
         id: `${Date.now()}-err`,
-        role: 'ora',
+        role: 'aura',
         content: "I couldn't connect right now. Try again in a moment.",
       }]);
     } finally {
@@ -195,7 +195,7 @@ export default function AuraOnboarding() {
       display: 'flex', alignItems: 'center', justifyContent: 'center',
       padding: 16,
     }}>
-      <div className="ora-onboarding-card" style={{
+      <div className="aura-onboarding-card" style={{
         width: '100%', maxWidth: 760, height: 'min(860px, calc(var(--visual-viewport-height, 100dvh) - 24px))',
         background: 'radial-gradient(circle at top, rgba(0,212,170,0.12), transparent 38%), #0a0a0f',
         border: '1px solid rgba(0,212,170,0.24)',
@@ -205,7 +205,7 @@ export default function AuraOnboarding() {
       }}>
         <div style={{ padding: '22px 22px 16px', borderBottom: '1px solid rgba(255,255,255,0.07)' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 16 }}>
-            <div className={complete ? 'ora-onboarding-pulse' : undefined} style={{
+            <div className={complete ? 'aura-onboarding-pulse' : undefined} style={{
               width: 52, height: 52, borderRadius: 26,
               background: 'linear-gradient(135deg, #00d4aa, #52ffd7)',
               color: '#0a0a0f', display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -324,12 +324,12 @@ export default function AuraOnboarding() {
         )}
       </div>
       <style>{`
-        .ora-onboarding-card { animation: oraOnboardingEnter 260ms ease-out; }
-        .ora-onboarding-pulse { animation: oraOnboardingPulse 900ms ease-in-out infinite alternate; }
-        @keyframes oraOnboardingEnter { from { transform: translateY(18px); opacity: 0.65; } to { transform: translateY(0); opacity: 1; } }
+        .aura-onboarding-card { animation: auraOnboardingEnter 260ms ease-out; }
+        .aura-onboarding-pulse { animation: auraOnboardingPulse 900ms ease-in-out infinite alternate; }
+        @keyframes auraOnboardingEnter { from { transform: translateY(18px); opacity: 0.65; } to { transform: translateY(0); opacity: 1; } }
         @keyframes oraOnboardingBounce { 0%, 80%, 100% { transform: translateY(0); opacity: 0.5; } 40% { transform: translateY(-6px); opacity: 1; } }
         @keyframes oraOnboardingPop { from { transform: scale(0.94); opacity: 0; } to { transform: scale(1); opacity: 1; } }
-        @keyframes oraOnboardingPulse { from { transform: scale(1); } to { transform: scale(1.06); } }
+        @keyframes auraOnboardingPulse { from { transform: scale(1); } to { transform: scale(1.06); } }
       `}</style>
     </div>
   );

--- a/src/components/GoalClarifyModal.tsx
+++ b/src/components/GoalClarifyModal.tsx
@@ -12,7 +12,7 @@ interface ChatMessage extends GoalClarifyMessage {
 }
 
 function AuraBubble({ message }: { message: ChatMessage }) {
-  const isAura = message.role === 'ora';
+  const isAura = message.role === 'aura';
   return (
     <div style={{ display: 'flex', flexDirection: isAura ? 'row' : 'row-reverse', gap: 8, marginBottom: 10, alignItems: 'flex-end' }}>
       {isAura && (
@@ -57,9 +57,9 @@ function isAuraManagedNode(node: any) {
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
-  return node.owner === 'ora'
+  return node.owner === 'aura'
     || haystack.includes('aura')
-    || haystack.includes('ora')
+    || haystack.includes('aura')
     || haystack.includes('map prerequisite')
     || haystack.includes('bridge node')
     || haystack.includes('find real options')
@@ -69,13 +69,13 @@ function isAuraManagedNode(node: any) {
 
 function userActionNodes(path: any[]) {
   const nodes = (path || []).filter((node) => !isAuraManagedNode(node));
-  return nodes.length ? nodes : (path || []).filter((node) => node.user_action || node.owner !== 'ora');
+  return nodes.length ? nodes : (path || []).filter((node) => node.user_action || node.owner !== 'aura');
 }
 
 export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: GoalClarifyModalProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([{
     id: 'opening',
-    role: 'ora',
+    role: 'aura',
     content: `I'd love to help you get ${goalTitle}! Let me ask a few questions to build your perfect plan.`,
   }]);
   const [input, setInput] = useState('');
@@ -107,7 +107,7 @@ export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: Goa
     try {
       const conversation = nextMessages.map(({ role, content }) => ({ role, content }));
       const res = await AuraClient.clarifyGoal(goalTitle, conversation);
-      setMessages(prev => [...prev, { id: `${Date.now()}-ora`, role: 'ora', content: res.message }]);
+      setMessages(prev => [...prev, { id: `${Date.now()}-aura`, role: 'aura', content: res.message }]);
       if (res.is_complete) {
         setStructuredGoal(res.structured_goal || { title: goalTitle });
         setIooPath(res.suggested_ioo_path || []);
@@ -115,7 +115,7 @@ export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: Goa
     } catch (e) {
       setMessages(prev => [...prev, {
         id: `${Date.now()}-err`,
-        role: 'ora',
+        role: 'aura',
         content: "I couldn't connect right now. Try again in a moment.",
       }]);
     } finally {
@@ -139,9 +139,9 @@ export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: Goa
     try {
       const res = await AuraClient.createServiceOrder(
         node.service_id,
-        `Goal: ${structuredGoal?.title || goalTitle}\nNode: ${node.title}\nAura action: ${node.ora_action || node.description || ''}`,
+        `Goal: ${structuredGoal?.title || goalTitle}\nNode: ${node.title}\nAura action: ${node.aura_action || node.description || ''}`,
         undefined,
-        { source: 'goal_clarify_modal', campaign: 'ioo_paid_ora_node', content: node.node_type || node.step_type },
+        { source: 'goal_clarify_modal', campaign: 'ioo_paid_aura_node', content: node.node_type || node.step_type },
         { quoted_price_usd: node.price_usd, quote_reason: node.pricing_note || node.pricing_level || 'dynamic_goal_quote' },
       );
       if (res?.checkout_url) window.location.href = res.checkout_url;
@@ -217,17 +217,17 @@ export default function GoalClarifyModal({ goalTitle, onClose, onComplete }: Goa
                     </div>
                   )}
                   {userActionNodes(iooPath).slice(0, 5).map((node, i) => (
-                    <div key={node.id || i} style={{ display: 'flex', gap: 10, padding: 10, borderRadius: 12, background: node.owner === 'ora' ? 'rgba(0,212,170,0.07)' : 'rgba(255,255,255,0.04)', border: node.owner === 'ora' ? '1px solid rgba(0,212,170,0.18)' : '1px solid rgba(255,255,255,0.06)' }}>
+                    <div key={node.id || i} style={{ display: 'flex', gap: 10, padding: 10, borderRadius: 12, background: node.owner === 'aura' ? 'rgba(0,212,170,0.07)' : 'rgba(255,255,255,0.04)', border: node.owner === 'aura' ? '1px solid rgba(0,212,170,0.18)' : '1px solid rgba(255,255,255,0.06)' }}>
                       <div style={{ width: 24, height: 24, borderRadius: 12, background: '#00d4aa', color: '#0a0a0f', fontSize: 12, fontWeight: 900, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{i + 1}</div>
                       <div style={{ minWidth: 0, flex: 1 }}>
                         <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap', marginBottom: 3 }}>
-                          <span style={{ fontSize: 10, color: node.owner === 'ora' ? '#00d4aa' : 'rgba(248,248,252,0.48)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 999, padding: '2px 7px', fontWeight: 800 }}>{node.owner === 'ora' ? 'Aura can do' : 'You do'}</span>
+                          <span style={{ fontSize: 10, color: node.owner === 'aura' ? '#00d4aa' : 'rgba(248,248,252,0.48)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 999, padding: '2px 7px', fontWeight: 800 }}>{node.owner === 'aura' ? 'Aura can do' : 'You do'}</span>
                           {node.node_type && <span style={{ fontSize: 10, color: 'rgba(248,248,252,0.36)' }}>{node.node_type}</span>}
                         </div>
                         <div style={{ fontSize: 13, fontWeight: 700 }}>{node.title || 'First step'}</div>
                         {node.description && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.5)', lineHeight: 1.45, marginTop: 2 }}>{node.description}</div>}
                         {node.user_action && <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.56)', lineHeight: 1.45, marginTop: 6 }}><b>You:</b> {node.user_action}</div>}
-                        {node.ora_action && <div style={{ fontSize: 12, color: 'rgba(0,212,170,0.78)', lineHeight: 1.45, marginTop: 4 }}><b>Aura:</b> {node.ora_action}</div>}
+                        {node.aura_action && <div style={{ fontSize: 12, color: 'rgba(0,212,170,0.78)', lineHeight: 1.45, marginTop: 4 }}><b>Aura:</b> {node.aura_action}</div>}
                         {node.requires_payment && node.service_id && (
                           <>
                           {(node.pricing_level || node.pricing_note) && <div style={{ fontSize: 11, color: 'rgba(248,248,252,0.38)', lineHeight: 1.4, marginTop: 7 }}>{node.pricing_level ? `Quote: ${node.pricing_level}. ` : ''}{node.pricing_note || ''}</div>}

--- a/src/components/SuggestionButton.tsx
+++ b/src/components/SuggestionButton.tsx
@@ -23,7 +23,7 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 interface SubmissionResult {
-  ora_response: string;
+  aura_response: string;
   cp_earned: number;
   total_dao_cp: number;
 }
@@ -76,7 +76,7 @@ export default function SuggestionButton() {
     try {
       const res = await AuraClient.submitSuggestion(content.trim(), category, pageContext);
       setResult({
-        ora_response: res.ora_response,
+        aura_response: res.aura_response,
         cp_earned: res.cp_earned,
         total_dao_cp: res.total_dao_cp,
       });
@@ -174,7 +174,7 @@ export default function SuggestionButton() {
                   fontStyle: 'italic',
                   textAlign: 'left',
                 }}>
-                  {result.ora_response}
+                  {result.aura_response}
                 </div>
                 <div style={{
                   display: 'flex',

--- a/src/index.css
+++ b/src/index.css
@@ -234,7 +234,7 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 
 /* ─── AuraPage fixed chat shell ────────────────────────────────── */
-.ora-container {
+.aura-container {
   position: fixed !important;
   top: 0 !important;
   left: 0 !important;
@@ -242,7 +242,7 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px)) !important;
 }
 @media (min-width: 1024px) {
-  .ora-container {
+  .aura-container {
     left: 240px !important;
     bottom: 0 !important;
   }
@@ -449,7 +449,7 @@ body {
 }
 
 .connectome-brand,
-.connectome-ora-indicator,
+.connectome-aura-indicator,
 .connectome-launcher-toggle,
 .connectome-status button:not(.connectome-feedback-btn),
 .connectome-dock__item {
@@ -595,7 +595,7 @@ body {
 }
 
 
-.connectome-ora-indicator {
+.connectome-aura-indicator {
   justify-self: center;
   display: inline-flex;
   align-items: center;
@@ -610,7 +610,7 @@ body {
   letter-spacing: 0.02em;
 }
 
-.ora-orb {
+.aura-orb {
   width: 13px;
   height: 13px;
   flex: 0 0 auto;
@@ -621,8 +621,8 @@ body {
   animation: oraPulse 2.8s ease-in-out infinite;
 }
 
-.ora-orb--large { width: 34px; height: 34px; }
-.ora-orb--small { width: 22px; height: 22px; }
+.aura-orb--large { width: 34px; height: 34px; }
+.aura-orb--small { width: 22px; height: 22px; }
 
 @keyframes oraPulse {
   0%, 100% { transform: scale(1); filter: saturate(1); opacity: 0.82; }
@@ -725,7 +725,7 @@ body {
   box-shadow: 0 0 28px rgba(0,212,170,0.18), inset 0 0 0 1px rgba(0,212,170,0.18);
 }
 
-.connectome-dock__item--ora span {
+.connectome-dock__item--aura span {
   color: #00d4aa;
   text-shadow: 0 0 18px rgba(0,212,170,0.8);
 }
@@ -860,7 +860,7 @@ body.keyboard-open .global-feedback-fab {
 .connectome-home__activity p { padding: 14px 0; border-top: 1px solid rgba(255,255,255,0.06); color: rgba(248,248,252,0.65); }
 
 .connectome-launcher-sheet,
-.ora-overlay {
+.aura-overlay {
   position: fixed;
   inset: 0;
   z-index: 180;
@@ -899,7 +899,7 @@ body.keyboard-open .global-feedback-fab {
 }
 
 .connectome-launcher-sheet__close,
-.ora-overlay__close {
+.aura-overlay__close {
   position: absolute;
   top: 16px;
   right: 16px;
@@ -928,9 +928,9 @@ body.keyboard-open .global-feedback-fab {
 .app-launcher__description { margin-top: 8px; color: rgba(248,248,252,0.55); font-size: 14px; line-height: 1.45; }
 .app-launcher__soon { margin-top: auto; color: #00d4aa; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
 
-.ora-overlay { display: grid; place-items: center; padding: 18px; }
-.ora-overlay__scrim { position: absolute; inset: 0; background: rgba(2,3,10,0.58); backdrop-filter: blur(16px); }
-.ora-overlay__panel {
+.aura-overlay { display: grid; place-items: center; padding: 18px; }
+.aura-overlay__scrim { position: absolute; inset: 0; background: rgba(2,3,10,0.58); backdrop-filter: blur(16px); }
+.aura-overlay__panel {
   position: relative;
   z-index: 1;
   width: min(760px, 100%);
@@ -944,27 +944,27 @@ body.keyboard-open .global-feedback-fab {
   flex-direction: column;
   overflow: hidden;
 }
-.ora-overlay__header { position: relative; padding: 18px 22px 14px; border-bottom: 1px solid rgba(255,255,255,0.08); }
-.ora-overlay__handle { width: 44px; height: 4px; margin: 0 auto 14px; border-radius: 999px; background: rgba(255,255,255,0.24); }
-.ora-overlay__identity { display: flex; align-items: center; gap: 14px; }
-.ora-overlay__eyebrow { color: rgba(248,248,252,0.42); font-size: 11px; text-transform: uppercase; letter-spacing: 0.15em; font-weight: 800; }
-.ora-overlay__identity h2 { margin: 2px 0 0; font-size: 30px; letter-spacing: -0.06em; }
-.ora-overlay__messages { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
-.ora-overlay__message { display: flex; align-items: flex-end; gap: 10px; }
-.ora-overlay__message > div { max-width: min(72%, 520px); padding: 13px 16px; border-radius: 20px; line-height: 1.55; font-size: 15px; }
-.ora-overlay__message--ora > div { background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.08); border-bottom-left-radius: 6px; }
-.ora-overlay__message--user { justify-content: flex-end; }
-.ora-overlay__message--user > div { background: rgba(0,212,170,0.16); border: 1px solid rgba(0,212,170,0.28); border-bottom-right-radius: 6px; }
-.ora-overlay__typing { display: flex; gap: 5px; }
-.ora-overlay__typing span { width: 7px; height: 7px; border-radius: 999px; background: #00d4aa; animation: bounce 1.2s ease-in-out infinite; }
-.ora-overlay__typing span:nth-child(2) { animation-delay: 0.15s; }
-.ora-overlay__typing span:nth-child(3) { animation-delay: 0.3s; }
-.ora-overlay__quick-actions { display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 20px 14px; }
-.ora-overlay__quick-context { flex: 0 0 auto; min-height: 28px; display: inline-flex; align-items: center; padding: 0 10px; border-radius: 999px; background: rgba(0,212,170,0.12); color: rgba(0,212,170,0.92); border: 1px solid rgba(0,212,170,0.18); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
-.ora-overlay__quick-actions button { flex: 0 0 auto; min-height: 38px; padding: 0 14px; border-radius: 999px; background: rgba(255,255,255,0.07); color: rgba(248,248,252,0.78); border: 1px solid rgba(255,255,255,0.08); font-size: 13px; }
-.ora-overlay__composer { display: flex; gap: 10px; padding: 16px 20px max(18px, env(safe-area-inset-bottom)); border-top: 1px solid rgba(255,255,255,0.08); }
-.ora-overlay__composer input { border-radius: 999px; background: rgba(255,255,255,0.07); }
-.ora-overlay__composer button { min-width: 82px; border-radius: 999px; background: #00d4aa; color: #04110f; }
+.aura-overlay__header { position: relative; padding: 18px 22px 14px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+.aura-overlay__handle { width: 44px; height: 4px; margin: 0 auto 14px; border-radius: 999px; background: rgba(255,255,255,0.24); }
+.aura-overlay__identity { display: flex; align-items: center; gap: 14px; }
+.aura-overlay__eyebrow { color: rgba(248,248,252,0.42); font-size: 11px; text-transform: uppercase; letter-spacing: 0.15em; font-weight: 800; }
+.aura-overlay__identity h2 { margin: 2px 0 0; font-size: 30px; letter-spacing: -0.06em; }
+.aura-overlay__messages { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+.aura-overlay__message { display: flex; align-items: flex-end; gap: 10px; }
+.aura-overlay__message > div { max-width: min(72%, 520px); padding: 13px 16px; border-radius: 20px; line-height: 1.55; font-size: 15px; }
+.aura-overlay__message--aura > div { background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.08); border-bottom-left-radius: 6px; }
+.aura-overlay__message--user { justify-content: flex-end; }
+.aura-overlay__message--user > div { background: rgba(0,212,170,0.16); border: 1px solid rgba(0,212,170,0.28); border-bottom-right-radius: 6px; }
+.aura-overlay__typing { display: flex; gap: 5px; }
+.aura-overlay__typing span { width: 7px; height: 7px; border-radius: 999px; background: #00d4aa; animation: bounce 1.2s ease-in-out infinite; }
+.aura-overlay__typing span:nth-child(2) { animation-delay: 0.15s; }
+.aura-overlay__typing span:nth-child(3) { animation-delay: 0.3s; }
+.aura-overlay__quick-actions { display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 20px 14px; }
+.aura-overlay__quick-context { flex: 0 0 auto; min-height: 28px; display: inline-flex; align-items: center; padding: 0 10px; border-radius: 999px; background: rgba(0,212,170,0.12); color: rgba(0,212,170,0.92); border: 1px solid rgba(0,212,170,0.18); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.aura-overlay__quick-actions button { flex: 0 0 auto; min-height: 38px; padding: 0 14px; border-radius: 999px; background: rgba(255,255,255,0.07); color: rgba(248,248,252,0.78); border: 1px solid rgba(255,255,255,0.08); font-size: 13px; }
+.aura-overlay__composer { display: flex; gap: 10px; padding: 16px 20px max(18px, env(safe-area-inset-bottom)); border-top: 1px solid rgba(255,255,255,0.08); }
+.aura-overlay__composer input { border-radius: 999px; background: rgba(255,255,255,0.07); }
+.aura-overlay__composer button { min-width: 82px; border-radius: 999px; background: #00d4aa; color: #04110f; }
 
 /* Reframe legacy full-screen pages inside the AIOS chrome. */
 .feed-container {
@@ -973,7 +973,7 @@ body.keyboard-open .global-feedback-fab {
   right: 0 !important;
   bottom: var(--shell-bottom-clearance) !important;
 }
-.ora-container {
+.aura-container {
   top: var(--top-header-height) !important;
   left: 0 !important;
   right: 0 !important;
@@ -992,7 +992,7 @@ body.aura-chat-active.keyboard-open {
   width: 100%;
 }
 
-body.keyboard-open .ora-container {
+body.keyboard-open .aura-container {
   bottom: auto !important;
   height: calc(var(--visual-viewport-height, 100dvh) - var(--top-header-height, 56px)) !important;
   overflow: hidden !important;
@@ -1011,13 +1011,13 @@ body.aura-chat-active.keyboard-open .connectome-dock {
   bottom: max(14px, env(safe-area-inset-bottom, 0px)) !important;
 }
 
-body.aura-chat-active.keyboard-open .ora-container {
+body.aura-chat-active.keyboard-open .aura-container {
   bottom: auto !important;
   height: calc(var(--visual-viewport-height, 100dvh) - var(--top-header-height, 56px)) !important;
 }
 
 @media (max-width: 760px) {
-  body.aura-chat-active.keyboard-open .ora-container {
+  body.aura-chat-active.keyboard-open .aura-container {
     top: 0 !important;
     height: var(--visual-viewport-height, 100dvh) !important;
   }
@@ -1026,7 +1026,7 @@ body.aura-chat-active.keyboard-open .ora-container {
 @media (min-width: 1024px) {
   .app-authenticated { padding-left: 0; }
   .feed-container { left: 0 !important; bottom: var(--shell-bottom-clearance) !important; }
-  .ora-container { left: 0 !important; }
+  .aura-container { left: 0 !important; }
 }
 
 @media (max-width: 760px) {
@@ -1043,7 +1043,7 @@ body.aura-chat-active.keyboard-open .ora-container {
 
   .connectome-brand small,
   .connectome-context-label,
-  .connectome-ora-indicator span:last-child,
+  .connectome-aura-indicator span:last-child,
   .connectome-app-titlebar small,
   .connectome-signout { display: none; }
   .connectome-brand strong { font-size: 14px; }
@@ -1055,9 +1055,9 @@ body.aura-chat-active.keyboard-open .ora-container {
   .connectome-home__highlights,
   .app-launcher__grid { grid-template-columns: 1fr; }
   .connectome-home h1 { font-size: clamp(36px, 14vw, 62px); }
-  .ora-overlay { padding: 0; align-items: stretch; }
-  .ora-overlay__panel { width: 100%; height: var(--visual-viewport-height, 100dvh); border-radius: 0; border-left: none; border-right: none; }
-  .ora-overlay__message > div { max-width: 82%; }
+  .aura-overlay { padding: 0; align-items: stretch; }
+  .aura-overlay__panel { width: 100%; height: var(--visual-viewport-height, 100dvh); border-radius: 0; border-left: none; border-right: none; }
+  .aura-overlay__message > div { max-width: 82%; }
 }
 
 /* Meta-app shells: iVive + Eviva */
@@ -1279,14 +1279,14 @@ body.aura-chat-active.keyboard-open .ora-container {
   .global-feedback-modal-backdrop { align-items: center; }
 }
 
-.ora-overlay__message-actions {
+.aura-overlay__message-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 10px;
 }
 
-.ora-overlay__message-actions button {
+.aura-overlay__message-actions button {
   border: 1px solid rgba(0, 212, 170, 0.34);
   background: rgba(0, 212, 170, 0.12);
   color: #b7fff0;
@@ -1297,7 +1297,7 @@ body.aura-chat-active.keyboard-open .ora-container {
   cursor: pointer;
 }
 
-.ora-overlay__message-actions button:disabled {
+.aura-overlay__message-actions button:disabled {
   opacity: 0.52;
   cursor: wait;
 }

--- a/src/lib/AuraClient.ts
+++ b/src/lib/AuraClient.ts
@@ -160,11 +160,11 @@ export interface GoalStep {
   resources?: Array<{ label: string; url: string }>;
   completed: boolean;
   order: number;
-  ora_note?: string;
+  aura_note?: string;
 }
 
 export interface GoalClarifyMessage {
-  role: 'user' | 'ora';
+  role: 'user' | 'aura';
   content: string;
 }
 
@@ -176,7 +176,7 @@ export interface GoalClarifyResponse {
 }
 
 export interface OnboardingMessage {
-  role: 'user' | 'ora';
+  role: 'user' | 'aura';
   content: string;
 }
 
@@ -231,7 +231,7 @@ export interface JournalEntry {
   id: string;
   prompt: string;
   response: string;
-  ora_reflection: string;
+  aura_reflection: string;
   created_at: string;
 }
 
@@ -516,9 +516,9 @@ class AuraClientClass {
     return res.data as { id: string; prompt: string };
   }
 
-  async submitJournalEntry(promptId: string, response: string): Promise<{ ora_reflection: string }> {
+  async submitJournalEntry(promptId: string, response: string): Promise<{ aura_reflection: string }> {
     const res = await this.client.post('/api/journal/entry', { prompt_id: promptId, response });
-    return res.data as { ora_reflection: string };
+    return res.data as { aura_reflection: string };
   }
 
   async getJournalEntries(): Promise<JournalEntry[]> {
@@ -532,23 +532,23 @@ class AuraClientClass {
     message: string,
     history: { role: string; content: string }[],
     context: { route?: string; app_context?: Record<string, any> } = {},
-  ): Promise<{ reply: string; ora_state: any; aura_state?: any; suggested_actions?: AuraChatAction[] }> {
-    const res = await this.client.post('/api/ora/chat', {
+  ): Promise<{ reply: string; aura_state: any; suggested_actions?: AuraChatAction[] }> {
+    const res = await this.client.post('/api/aura/chat', {
       message,
       conversation_history: history.map(h => ({ role: h.role, content: h.content })),
       route: context.route,
       app_context: context.app_context,
     });
-    return res.data as { reply: string; ora_state: any; aura_state?: any; suggested_actions?: AuraChatAction[] };
+    return res.data as { reply: string; aura_state: any; suggested_actions?: AuraChatAction[] };
   }
 
-  async getOraSelf(): Promise<any> {
-    const res = await this.client.get('/api/ora/self');
+  async getAuraSelf(): Promise<any> {
+    const res = await this.client.get('/api/aura/self');
     return res.data;
   }
 
   async getOpeningMessage(): Promise<{ message: string }> {
-    const res = await this.client.get('/api/ora/opening');
+    const res = await this.client.get('/api/aura/opening');
     return res.data as { message: string };
   }
 
@@ -678,7 +678,7 @@ class AuraClientClass {
       suggestion: any;
       cp_earned: number;
       total_dao_cp: number;
-      ora_response: string;
+      aura_response: string;
       message: string;
     };
   }
@@ -708,7 +708,7 @@ class AuraClientClass {
       suggestion: any;
       cp_earned: number;
       total_dao_cp: number;
-      ora_response: string;
+      aura_response: string;
     };
   }
 
@@ -810,7 +810,7 @@ class AuraClientClass {
 
   async submitDailyCheckin(payload: { mood_index: number; capacity: string; focus: string; blocker?: string }) {
     const res = await this.client.post('/api/mood/daily-checkin', payload);
-    return res.data as { ok: boolean; mood: string; xp_awarded: number; ora_focus: string; active_goal?: { id: string; title: string } | null };
+    return res.data as { ok: boolean; mood: string; xp_awarded: number; aura_focus: string; active_goal?: { id: string; title: string } | null };
   }
 
   // ── A/B Testing ────────────────────────────────────────────────────────────────────────────────

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import AuthCallbackPage from './pages/AuthCallbackPage'
 import GitHubCallbackPage from './pages/GitHubCallbackPage'
 import ConnectomeHome from './pages/ConnectomeHome'
 import FeedPage from './pages/FeedPage'
-import AuraPage from './pages/OraPage'
+import AuraPage from './pages/AuraPage'
 import GoalsPage from './pages/GoalsPage'
 import RoutinesPage from './pages/RoutinesPage'
 import DAOPage from './pages/DAOPage'
@@ -58,7 +58,7 @@ function useKeyboardViewport() {
       // Fixed app surfaces (Aura chat/feed sheets) handle their own keyboard
       // geometry. Browser scrollIntoView centering makes the composer float too
       // far above the keyboard on mobile Safari.
-      if (active.closest('.ora-container, .feed-container, .ora-overlay')) return
+      if (active.closest('.aura-container, .feed-container, .aura-overlay')) return
 
       window.requestAnimationFrame(() => {
         const viewportHeight = window.visualViewport?.height ?? window.innerHeight
@@ -163,7 +163,8 @@ function App() {
           <Route path="/app" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
           <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
           <Route path="/app/future" element={<Navigate to="/app/ido" replace />} />
-          <Route path="/app/ora" element={<ShellRoute activeApp="ora"><AuraPage /></ShellRoute>} />
+          <Route path="/app/aura" element={<ShellRoute activeApp="aura"><AuraPage /></ShellRoute>} />
+          <Route path="/app/aura" element={<Navigate to="/app/aura" replace />} />
           <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
           <Route path="/app/routines" element={<ShellRoute activeApp="routines"><RoutinesPage /></ShellRoute>} />
           <Route path="/app/dao" element={<ShellRoute activeApp="dao"><DAOPage /></ShellRoute>} />
@@ -190,7 +191,8 @@ function App() {
           <Route path="/goals" element={<Navigate to="/app/goals" replace />} />
           <Route path="/routines" element={<Navigate to="/app/routines" replace />} />
           <Route path="/journal" element={<Navigate to="/app/ido" replace />} />
-          <Route path="/ora" element={<Navigate to="/app/ora" replace />} />
+          <Route path="/aura" element={<Navigate to="/app/aura" replace />} />
+          <Route path="/ora" element={<Navigate to="/app/aura" replace />} />
           <Route path="/dao" element={<Navigate to="/app/dao" replace />} />
           <Route path="/contribute" element={<Navigate to="/app/contribute" replace />} />
           <Route path="/profile" element={<Navigate to="/app/profile" replace />} />

--- a/src/pages/AuraPage.tsx
+++ b/src/pages/AuraPage.tsx
@@ -4,7 +4,7 @@ import { useExperiment } from '../lib/useExperiment';
 
 interface Message {
   id: string;
-  role: 'user' | 'ora';
+  role: 'user' | 'aura';
   content: string;
   ts: number;
 }
@@ -14,7 +14,7 @@ function formatTime(ts: number) {
 }
 
 function OraMessage({ msg, showTime }: { msg: Message; showTime: boolean }) {
-  const isAura = msg.role === 'ora';
+  const isAura = msg.role === 'aura';
   return (
     <div style={{
       display: 'flex',
@@ -103,7 +103,7 @@ function DailyMomentumCheckin({ onComplete }: { onComplete: (reply: string) => v
     try {
       const res = await AuraClient.submitDailyCheckin({ mood_index: mood, capacity, focus: focus.trim(), blocker: blocker.trim() || undefined });
       setDone(true);
-      onComplete(`${res.ora_focus}${res.xp_awarded ? `\n\n+${res.xp_awarded} XP for checking in.` : ''}`);
+      onComplete(`${res.aura_focus}${res.xp_awarded ? `\n\n+${res.xp_awarded} XP for checking in.` : ''}`);
     } catch {
       onComplete('Check-in saved locally in spirit — tell me your one focus and I’ll help you make it concrete.');
     } finally {
@@ -116,7 +116,7 @@ function DailyMomentumCheckin({ onComplete }: { onComplete: (reply: string) => v
   return (
     <div style={{ marginBottom: 14, padding: 14, borderRadius: 22, border: '1px solid rgba(0,212,170,0.22)', background: 'linear-gradient(135deg, rgba(0,212,170,0.10), rgba(255,255,255,0.035))' }}>
       <div style={{ color: '#00d4aa', fontSize: 11, fontWeight: 900, letterSpacing: 1, textTransform: 'uppercase' }}>30-second momentum check-in</div>
-      <div style={{ color: '#f8f8fc', fontWeight: 850, marginTop: 6 }}>How should Ora tune today?</div>
+      <div style={{ color: '#f8f8fc', fontWeight: 850, marginTop: 6 }}>How should Aura tune today?</div>
       <div style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
         {['Exhausted', 'Neutral', 'Okay', 'Good', 'Energised'].map((label, i) => (
           <button key={label} onClick={() => setMood(i)} style={{ padding: '7px 10px', borderRadius: 999, background: mood === i ? '#00d4aa' : 'rgba(255,255,255,0.06)', color: mood === i ? '#07110f' : 'rgba(248,248,252,0.72)', fontSize: 12, fontWeight: 800 }}>{label}</button>
@@ -136,9 +136,9 @@ function DailyMomentumCheckin({ onComplete }: { onComplete: (reply: string) => v
 
 export default function AuraPage() {
   // ─── A/B experiments ────────────────────────────────────────────────────
-  const { variant: greetingVariant } = useExperiment('ora_greeting');
-  const { variant: responseLengthVariant } = useExperiment('ora_response_length');
-  const { variant: proactiveSuggestionsVariant, trackEvent: trackAuraEvent } = useExperiment('ora_proactive_suggestions');
+  const { variant: greetingVariant } = useExperiment('aura_greeting');
+  const { variant: responseLengthVariant } = useExperiment('aura_response_length');
+  const { variant: proactiveSuggestionsVariant, trackEvent: trackAuraEvent } = useExperiment('aura_proactive_suggestions');
 
   const AURA_GREETINGS: Record<string, string> = {
     A: "Hey! I'm Aura. What do you want to work toward?",
@@ -165,12 +165,12 @@ export default function AuraPage() {
   useEffect(() => {
     Promise.all([
       AuraClient.getOpeningMessage().catch(() => null),
-      AuraClient.getOraSelf().catch(() => null),
+      AuraClient.getAuraSelf().catch(() => null),
     ]).then(([opening, self]) => {
       // Use A/B greeting variant if no server-provided message
       const defaultGreeting = AURA_GREETINGS[greetingVariant] || AURA_GREETINGS['A'];
       const content = opening?.message || defaultGreeting;
-      setMessages([{ id: 'opening', role: 'ora', content, ts: Date.now() }]);
+      setMessages([{ id: 'opening', role: 'aura', content, ts: Date.now() }]);
       if (self) setAuraInfo(self);
     }).finally(() => setLoadingOpening(false));
   }, []);
@@ -218,13 +218,13 @@ export default function AuraPage() {
 
     try {
       const history = messages.slice(-12).map((m) => ({
-        role: m.role === 'ora' ? 'assistant' : 'user',
+        role: m.role === 'aura' ? 'assistant' : 'user',
         content: m.content,
       }));
       const res = await AuraClient.chat(text, history);
       setMessages((prev) => [...prev, {
-        id: Date.now().toString() + '-ora',
-        role: 'ora',
+        id: Date.now().toString() + '-aura',
+        role: 'aura',
         content: res.reply,
         ts: Date.now(),
       }]);
@@ -232,7 +232,7 @@ export default function AuraPage() {
       const errMsg = e?.response?.data?.detail || 'Something went wrong. Try again.';
       setMessages((prev) => [...prev, {
         id: Date.now().toString() + '-err',
-        role: 'ora',
+        role: 'aura',
         content: typeof errMsg === 'string' ? errMsg : 'Something went wrong.',
         ts: Date.now(),
       }]);
@@ -251,14 +251,14 @@ export default function AuraPage() {
   const clearChat = () => {
     setMessages([{
       id: 'clear-' + Date.now(),
-      role: 'ora',
+      role: 'aura',
       content: "Fresh start. What would you like to explore?",
       ts: Date.now(),
     }]);
   };
 
   const handleDailyMomentum = (reply: string) => {
-    setMessages((prev) => [...prev, { id: 'daily-' + Date.now(), role: 'ora', content: reply, ts: Date.now() }]);
+    setMessages((prev) => [...prev, { id: 'daily-' + Date.now(), role: 'aura', content: reply, ts: Date.now() }]);
   };
 
   // Show timestamps on last message per group
@@ -268,7 +268,7 @@ export default function AuraPage() {
   return (
     <div
       ref={containerRef}
-      className="ora-container"
+      className="aura-container"
       style={{
         maxWidth: 720,
         margin: '0 auto',

--- a/src/pages/ConnectomeHome.tsx
+++ b/src/pages/ConnectomeHome.tsx
@@ -42,7 +42,7 @@ export default function ConnectomeHome() {
     <div className="connectome-home" style={{ maxWidth: 1040, margin: '0 auto', padding: '78px 18px 120px' }}>
       <section className="connectome-home__hero" style={{ textAlign: 'center', marginBottom: 26 }}>
         <div className="connectome-home__signal">
-          <span className="ora-orb" /> Aura is online
+          <span className="aura-orb" /> Aura is online
         </div>
         <h1>Your AI OS for Human Flourishing</h1>
         <p style={{ maxWidth: 720, margin: '0 auto 10px' }}>

--- a/src/pages/DAOPage.tsx
+++ b/src/pages/DAOPage.tsx
@@ -787,7 +787,7 @@ export default function DAOPage() {
                           <div style={{ fontSize: 10, color: 'rgba(248,248,252,0.35)' }}>CP</div>
                         </div>
                       </div>
-                      {item.ora_evaluation && (
+                      {item.aura_evaluation && (
                         <div style={{
                           marginTop: 10, background: 'rgba(99,102,241,0.08)',
                           borderLeft: '2px solid #6366f1', borderRadius: '0 8px 8px 0',
@@ -795,7 +795,7 @@ export default function DAOPage() {
                         }}>
                           <div style={{ fontSize: 9, color: '#6366f1', fontWeight: 700, letterSpacing: 0.5, marginBottom: 3 }}>AURA'S TAKE</div>
                           <div style={{ fontSize: 12, color: 'rgba(248,248,252,0.55)', fontStyle: 'italic', lineHeight: 1.5 }}>
-                            {item.ora_evaluation}
+                            {item.aura_evaluation}
                           </div>
                         </div>
                       )}

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -597,7 +597,7 @@ function isSystemManagedPathStep(step: any) {
     || text.includes('generate')
     || text.includes('rank')
     || text.includes('aura should')
-    || text.includes('ora should');
+    || text.includes('aura should');
 }
 
 function PathwaySheet({ data, onClose, onInvite }: { data: any; onClose: () => void; onInvite: () => void }) {

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -124,9 +124,9 @@ function isAuraManagedNode(node: any) {
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
-  return node.owner === 'ora'
+  return node.owner === 'aura'
     || haystack.includes('aura')
-    || haystack.includes('ora')
+    || haystack.includes('aura')
     || haystack.includes('map prerequisite')
     || haystack.includes('bridge node')
     || haystack.includes('find real options')
@@ -136,7 +136,7 @@ function isAuraManagedNode(node: any) {
 
 function userActionNodes(path: any[]) {
   const nodes = (path || []).filter((node) => !isAuraManagedNode(node));
-  return nodes.length ? nodes : (path || []).filter((node) => node.user_action || node.owner !== 'ora');
+  return nodes.length ? nodes : (path || []).filter((node) => node.user_action || node.owner !== 'aura');
 }
 
 function UserStateStrip({ goals }: { goals: Goal[] }) {
@@ -260,7 +260,7 @@ function GoalCard({ goal, onUpdate, onDelete, onOpenFeed }: { goal: Goal; onUpda
   const intention = goal.intention_text || goal.graph_metadata?.intention_text;
   const measurable = goal.measurable_outcome || goal.graph_metadata?.measurable_outcome || goal.title;
   const metricLine = [goal.success_metric, goal.target_value, goal.target_date].filter(Boolean).join(' • ');
-  const auraManagedCount = goal.graph_metadata?.aura_managed_nodes?.length || goal.graph_metadata?.ora_nodes?.length || 0;
+  const auraManagedCount = goal.graph_metadata?.aura_managed_nodes?.length || goal.graph_metadata?.aura_nodes?.length || 0;
 
   const breakdown = async () => {
     setBusy('breakdown');
@@ -294,7 +294,7 @@ function GoalCard({ goal, onUpdate, onDelete, onOpenFeed }: { goal: Goal; onUpda
 
   const askAura = async () => {
     if (!step) return;
-    setBusy('ora');
+    setBusy('aura');
     try {
       const res = await AuraClient.chat(`This intention has become a specific goal in my living collection: "${goal.title}". Current step: "${step.text}". Help me refine the smallest measurable next move, in 2-3 sentences.`, []);
       setAuraReply(res.reply);
@@ -469,13 +469,13 @@ export default function GoalsPage() {
       detail: [
         node.description,
         node.user_action ? `You: ${node.user_action}` : null,
-        node.ora_action ? `Aura: ${node.ora_action}` : null,
+        node.aura_action ? `Aura: ${node.aura_action}` : null,
         node.requires_payment ? `Unlock: ${node.service_id || 'Aura service'}${node.price_usd ? ` • $${node.price_usd}` : ''}` : null,
       ].filter(Boolean).join('\n'),
       resources: [],
       completed: false,
       order: i,
-      ora_note: [
+      aura_note: [
         node.domain ? `Path map • ${node.domain}` : 'Path map',
         node.owner ? `Owner: ${node.owner}` : null,
         node.node_type || node.step_type || null,
@@ -505,9 +505,9 @@ export default function GoalsPage() {
         measurable_outcome: structuredGoal?.measurable_outcome || structuredGoal?.specifics || structuredGoal?.title || title,
         suggested_ioo_path: iooPath,
         aura_managed_nodes: iooPath.filter(isAuraManagedNode),
-        user_nodes: iooPath.filter((node) => node.owner !== 'ora'),
-        ora_nodes: iooPath.filter((node) => node.owner === 'ora'),
-        paid_ora_nodes: iooPath.filter((node) => node.requires_payment),
+        user_nodes: iooPath.filter((node) => node.owner !== 'aura'),
+        aura_nodes: iooPath.filter((node) => node.owner === 'aura'),
+        paid_aura_nodes: iooPath.filter((node) => node.requires_payment),
         source: 'goals_collection',
       },
     });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -268,7 +268,7 @@ export default function HomePage() {
 
           {/* Clarifying question — Variant B only */}
           {knowVariant === 'clarifying' && (
-            <div style={{ marginBottom: 20 }} className="ora-fade-in">
+            <div style={{ marginBottom: 20 }} className="aura-fade-in">
               <label style={{
                 display: 'block', fontSize: 13, fontWeight: 600,
                 color: 'rgba(248,248,252,0.5)', marginBottom: 10, letterSpacing: 0.3,
@@ -743,7 +743,7 @@ function GlobalStyles() {
         0%, 100% { opacity: 1; }
         50% { opacity: 0.45; }
       }
-      .ora-fade-in {
+      .aura-fade-in {
         animation: oraFadeIn 0.3s ease-out;
       }
       @keyframes oraFadeIn {

--- a/src/pages/JournalPage.tsx
+++ b/src/pages/JournalPage.tsx
@@ -41,7 +41,7 @@ function EntryCard({ entry }: { entry: JournalEntry }) {
               {entry.response}
             </div>
           </div>
-          {entry.ora_reflection && (
+          {entry.aura_reflection && (
             <div style={{
               borderTop: '1px solid rgba(0,212,170,0.12)',
               background: 'rgba(0,212,170,0.04)',
@@ -51,7 +51,7 @@ function EntryCard({ entry }: { entry: JournalEntry }) {
                 ◈ AURA'S REFLECTION
               </div>
               <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.65)', lineHeight: 1.65, fontStyle: 'italic' }}>
-                {entry.ora_reflection}
+                {entry.aura_reflection}
               </div>
             </div>
           )}
@@ -87,7 +87,7 @@ export default function JournalPage() {
     setSubmitting(true);
     try {
       const res = await AuraClient.submitJournalEntry(prompt.id, text.trim());
-      setReflection(res.ora_reflection || '');
+      setReflection(res.aura_reflection || '');
       setSubmitted(true);
       show('Journal entry saved!', 'success');
       // Refresh entries

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -317,7 +317,7 @@ export default function ProfilePage() {
   const loadProposals = async () => {
     setProposalsLoading(true);
     try {
-      const res = await AuraClient['client'].get('/api/ora/autonomy/proposals');
+      const res = await AuraClient['client'].get('/api/aura/autonomy/proposals');
       setProposals(res.data?.proposals || []);
     } catch {}
     setProposalsLoading(false);
@@ -326,7 +326,7 @@ export default function ProfilePage() {
   const loadAgentPopulation = async () => {
     setAgentPopulationLoading(true);
     try {
-      const res = await AuraClient['client'].get('/api/ora/autonomy/evolution/population');
+      const res = await AuraClient['client'].get('/api/aura/autonomy/evolution/population');
       setAgentPopulation(res.data?.population || []);
     } catch {}
     setAgentPopulationLoading(false);
@@ -335,7 +335,7 @@ export default function ProfilePage() {
   const loadEvolutionProposals = async () => {
     setEvolutionProposalsLoading(true);
     try {
-      const res = await AuraClient['client'].get('/api/ora/autonomy/evolution/proposals');
+      const res = await AuraClient['client'].get('/api/aura/autonomy/evolution/proposals');
       setEvolutionProposals(res.data?.proposals || []);
     } catch {}
     setEvolutionProposalsLoading(false);
@@ -343,7 +343,7 @@ export default function ProfilePage() {
 
   const handleEvolutionProposal = async (id: string, action: 'approve' | 'reject') => {
     try {
-      await AuraClient['client'].post(`/api/ora/autonomy/evolution/proposals/${id}/${action}`);
+      await AuraClient['client'].post(`/api/aura/autonomy/evolution/proposals/${id}/${action}`);
       await loadEvolutionProposals();
     } catch (e: any) {
       alert(`Failed to ${action}: ${e?.response?.data?.detail || 'Unknown error'}`);
@@ -352,7 +352,7 @@ export default function ProfilePage() {
 
   const handleProposal = async (id: string, action: 'approve' | 'reject') => {
     try {
-      await AuraClient['client'].post(`/api/ora/autonomy/proposals/${id}/${action}`);
+      await AuraClient['client'].post(`/api/aura/autonomy/proposals/${id}/${action}`);
       await loadProposals();
     } catch (e: any) {
       alert(`Failed to ${action}: ${e?.response?.data?.detail || 'Unknown error'}`);
@@ -362,7 +362,7 @@ export default function ProfilePage() {
   const runAutonomy = async () => {
     setRunningAutonomy(true);
     try {
-      const res = await AuraClient['client'].post('/api/ora/autonomy/run');
+      const res = await AuraClient['client'].post('/api/aura/autonomy/run');
       setAutonomyStatus(res.data);
     } catch (e: any) {
       setAutonomyStatus({ error: e?.response?.data?.detail || 'Failed' });
@@ -1520,7 +1520,7 @@ export default function ProfilePage() {
           <Card title="Health Dashboard">
             <button
               onClick={async () => {
-                const res = await AuraClient['client'].get('/api/ora/health/dashboard').catch(() => ({ data: null }));
+                const res = await AuraClient['client'].get('/api/aura/health/dashboard').catch(() => ({ data: null }));
                 alert(JSON.stringify(res.data, null, 2));
               }}
               style={{ width: '100%', padding: '10px', borderRadius: 10, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(248,248,252,0.7)', fontWeight: 600, fontSize: 13 }}

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -42,7 +42,7 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-const isAiOsSetup = (service: Service) => service.id.startsWith('ora-ai-os-setup');
+const isAiOsSetup = (service: Service) => service.id.startsWith('aura-ai-os-setup');
 
 function getServiceAttribution(): ServiceAttribution {
   const params = new URLSearchParams(window.location.search);
@@ -358,7 +358,7 @@ export default function ServicesPage() {
         </div>
         <button
           onClick={() => {
-            const beta = services.find((s) => s.id === 'ora-ai-os-setup-beta') || services.find(isAiOsSetup);
+            const beta = services.find((s) => s.id === 'aura-ai-os-setup-beta') || services.find(isAiOsSetup);
             if (beta) setSelectedService(beta);
           }}
           disabled={!services.some(isAiOsSetup)}

--- a/src/runtime/ontology.ts
+++ b/src/runtime/ontology.ts
@@ -28,7 +28,7 @@ export type PrivacyTier = 'standard' | 'sensitive' | 'minimal';
 
 export interface PermissionGrant {
   domain: PermissionDomain;
-  scope: string[]; // e.g. ['ido', 'ora']
+  scope: string[]; // e.g. ['ido', 'aura']
   privacyTier: PrivacyTier;
   expiresAt?: string;
 }
@@ -37,7 +37,7 @@ export interface PermissionGrant {
 export type AppId =
   | 'home'
   | 'ido'
-  | 'ora'
+  | 'aura'
   | 'goals'
   | 'routines'
   | 'ivive'
@@ -140,7 +140,7 @@ export interface ActionDecision {
   id: string;
   targetEntity: { kind: string; id: string };
   decision: 'delegate' | 'plan' | 'ditch';
-  delegatedTo?: 'ora' | 'agent' | 'person';
+  delegatedTo?: 'aura' | 'agent' | 'person';
   planId?: string;
   reason?: string;
 }
@@ -154,7 +154,7 @@ export interface Opportunity {
   cost?: { amount: number; currency: string };
   servesNeeds: string[]; // Need.id[]
   fitScore?: number; // 0–1
-  source?: 'ido_feed' | 'domain_feed' | 'aventi' | 'eviva' | 'ivive' | 'dao' | 'ora' | 'partner';
+  source?: 'ido_feed' | 'domain_feed' | 'aventi' | 'eviva' | 'ivive' | 'dao' | 'aura' | 'partner';
 }
 
 export interface FeedSurface {
@@ -216,7 +216,7 @@ export interface DaoTask {
 
 export interface HealthSignal {
   id: string;
-  source: 'manual' | 'wearable' | 'inferred' | 'ora';
+  source: 'manual' | 'wearable' | 'inferred' | 'aura';
   kind: 'energy' | 'sleep' | 'mood' | 'recovery' | 'focus' | 'rest' | 'pomodoro' | 'biomarker';
   value: number;
   unit?: string;
@@ -225,7 +225,7 @@ export interface HealthSignal {
 }
 
 export type MemoryKind = 'fact' | 'preference' | 'story' | 'lesson' | 'commitment';
-export type MemoryFraming = 'ora_remembers' | 'profile_memory';
+export type MemoryFraming = 'aura_remembers' | 'profile_memory';
 
 export interface MemoryRecord {
   id: string;
@@ -370,10 +370,10 @@ export const FEED_SURFACES: FeedSurface[] = [
 // ─── App manifest (visible/invisible boundaries) ──────────────────────────────
 export const APP_MANIFEST: AppManifestEntry[] = [
   {
-    id: 'ora',
+    id: 'aura',
     name: 'Aura',
     icon: '◈',
-    path: '/app/ora',
+    path: '/app/aura',
     category: 'daily',
     visibleToUser: true,
     permissions: ['memory', 'notifications', 'files', 'calendar', 'location'],

--- a/src/shell/AppLauncher.tsx
+++ b/src/shell/AppLauncher.tsx
@@ -7,7 +7,7 @@ type ConnectomeApp = AppManifestEntry;
 
 type AiosState = {
   featured_apps?: string[];
-  ora_mission_statement?: string;
+  aura_mission_statement?: string;
 };
 
 export const CONNECTOME_APPS: ConnectomeApp[] = APP_MANIFEST.filter((app) => app.visibleToUser);
@@ -72,8 +72,8 @@ export default function AppLauncher({ onLaunch }: AppLauncherProps) {
       <div className="app-launcher__intro">
         <span>Aura</span>
         <h2>What are you trying to do?</h2>
-        {aiosState.ora_mission_statement && (
-          <p className="app-launcher__mission">{aiosState.ora_mission_statement}</p>
+        {aiosState.aura_mission_statement && (
+          <p className="app-launcher__mission">{aiosState.aura_mission_statement}</p>
         )}
       </div>
       <div className="app-launcher__grid">

--- a/src/shell/AuraOverlay.tsx
+++ b/src/shell/AuraOverlay.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AuraClient, type AuraChatAction } from '../lib/AuraClient';
 
-type Message = { id: string; role: 'user' | 'ora'; content: string; actions?: AuraChatAction[] };
+type Message = { id: string; role: 'user' | 'aura'; content: string; actions?: AuraChatAction[] };
 type QuickAction = { label: string; prompt: string; context: string };
 
 interface AuraOverlayProps {
@@ -76,7 +76,7 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: 'opening',
-      role: 'ora',
+      role: 'aura',
       content: "I'm Aura — your AI OS for human flourishing. Ask me anything, or choose a signal below and I'll orient the day around it.",
     },
   ]);
@@ -107,18 +107,18 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
 
     try {
       const history = messages.slice(-10).map((m) => ({
-        role: m.role === 'ora' ? 'assistant' : 'user',
+        role: m.role === 'aura' ? 'assistant' : 'user',
         content: m.content,
       }));
       const res = await AuraClient.chat(text, history, {
         route: `${location.pathname}${location.search}${location.hash}`,
         app_context: { app: quickActionContext, page: location.pathname },
       });
-      setMessages((prev) => [...prev, { id: `${Date.now()}-ora`, role: 'ora', content: res.reply, actions: res.suggested_actions || [] }]);
+      setMessages((prev) => [...prev, { id: `${Date.now()}-aura`, role: 'aura', content: res.reply, actions: res.suggested_actions || [] }]);
     } catch {
       setMessages((prev) => [...prev, {
         id: `${Date.now()}-fallback`,
-        role: 'ora',
+        role: 'aura',
         content: "I couldn't reach my deeper systems just now, but I'm still here. Try again in a moment.",
       }]);
     } finally {
@@ -138,12 +138,12 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
         );
         setMessages((prev) => [...prev, {
           id: `${Date.now()}-goal-created`,
-          role: 'ora',
+          role: 'aura',
           content: `Done — I created the goal “${goal.title}”. I can break it down into a path next.`,
           actions: [{ label: 'Break it into steps', action: 'chat_prompt', prompt: `Break my new goal “${goal.title}” into a practical path with the smallest next action first.` }],
         }]);
       } catch {
-        setMessages((prev) => [...prev, { id: `${Date.now()}-goal-error`, role: 'ora', content: 'I could not create that goal just now. Try again, or ask me to revise it first.' }]);
+        setMessages((prev) => [...prev, { id: `${Date.now()}-goal-error`, role: 'aura', content: 'I could not create that goal just now. Try again, or ask me to revise it first.' }]);
       } finally {
         setLoading(false);
       }
@@ -153,9 +153,9 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
       setLoading(true);
       try {
         await AuraClient.syncGoogleDrive();
-        setMessages((prev) => [...prev, { id: `${Date.now()}-drive-sync`, role: 'ora', content: 'Drive sync started. Ask me again in a moment and I’ll use the refreshed context.' }]);
+        setMessages((prev) => [...prev, { id: `${Date.now()}-drive-sync`, role: 'aura', content: 'Drive sync started. Ask me again in a moment and I’ll use the refreshed context.' }]);
       } catch {
-        setMessages((prev) => [...prev, { id: `${Date.now()}-drive-sync-error`, role: 'ora', content: 'I could not sync Drive from here. Check Profile → Google Drive permissions/privacy, then try again.' }]);
+        setMessages((prev) => [...prev, { id: `${Date.now()}-drive-sync-error`, role: 'aura', content: 'I could not sync Drive from here. Check Profile → Google Drive permissions/privacy, then try again.' }]);
       } finally {
         setLoading(false);
       }
@@ -176,29 +176,29 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
   if (!open) return null;
 
   return (
-    <div className="ora-overlay" role="dialog" aria-modal="true" aria-label="Aura OS overlay">
-      <div className="ora-overlay__scrim" onClick={onClose} />
-      <div className="ora-overlay__panel" ref={panelRef} onPointerDown={handlePointerDown}>
-        <header className="ora-overlay__header">
-          <div className="ora-overlay__handle" />
-          <div className="ora-overlay__identity">
-            <span className="ora-orb ora-orb--large" />
+    <div className="aura-overlay" role="dialog" aria-modal="true" aria-label="Aura OS overlay">
+      <div className="aura-overlay__scrim" onClick={onClose} />
+      <div className="aura-overlay__panel" ref={panelRef} onPointerDown={handlePointerDown}>
+        <header className="aura-overlay__header">
+          <div className="aura-overlay__handle" />
+          <div className="aura-overlay__identity">
+            <span className="aura-orb aura-orb--large" />
             <div>
-              <div className="ora-overlay__eyebrow">Aura · AIOS</div>
+              <div className="aura-overlay__eyebrow">Aura · AIOS</div>
               <h2>Aura — your guide</h2>
             </div>
           </div>
-          <button className="ora-overlay__close" type="button" onClick={onClose} aria-label="Close Aura">×</button>
+          <button className="aura-overlay__close" type="button" onClick={onClose} aria-label="Close Aura">×</button>
         </header>
 
-        <div className="ora-overlay__messages">
+        <div className="aura-overlay__messages">
           {messages.map((message) => (
-            <div key={message.id} className={`ora-overlay__message ora-overlay__message--${message.role}`}>
-              {message.role === 'ora' && <span className="ora-orb ora-orb--small" />}
+            <div key={message.id} className={`aura-overlay__message aura-overlay__message--${message.role}`}>
+              {message.role === 'aura' && <span className="aura-orb aura-orb--small" />}
               <div>
                 <div>{message.content}</div>
-                {message.role === 'ora' && Boolean(message.actions?.length) && (
-                  <div className="ora-overlay__message-actions" aria-label="Aura suggested actions">
+                {message.role === 'aura' && Boolean(message.actions?.length) && (
+                  <div className="aura-overlay__message-actions" aria-label="Aura suggested actions">
                     {message.actions!.map((action, index) => (
                       <button
                         key={`${message.id}:${index}:${action.label}`}
@@ -215,16 +215,16 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
             </div>
           ))}
           {loading && (
-            <div className="ora-overlay__message ora-overlay__message--ora">
-              <span className="ora-orb ora-orb--small" />
-              <div className="ora-overlay__typing"><span /><span /><span /></div>
+            <div className="aura-overlay__message aura-overlay__message--aura">
+              <span className="aura-orb aura-orb--small" />
+              <div className="aura-overlay__typing"><span /><span /><span /></div>
             </div>
           )}
           <div ref={endRef} />
         </div>
 
-        <div className="ora-overlay__quick-actions" aria-label={`${quickActionContext} quick actions`}>
-          <span className="ora-overlay__quick-context">{quickActionContext}</span>
+        <div className="aura-overlay__quick-actions" aria-label={`${quickActionContext} quick actions`}>
+          <span className="aura-overlay__quick-context">{quickActionContext}</span>
           {quickActions.actions.map((action) => (
             <button
               key={`${action.context}:${action.label}`}
@@ -237,7 +237,7 @@ export default function AuraOverlay({ open, onClose }: AuraOverlayProps) {
           ))}
         </div>
 
-        <form className="ora-overlay__composer" onSubmit={(event) => { event.preventDefault(); sendMessage(); }}>
+        <form className="aura-overlay__composer" onSubmit={(event) => { event.preventDefault(); sendMessage(); }}>
           <input
             value={input}
             onChange={(event) => setInput(event.target.value)}

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -31,7 +31,7 @@ type DockItem = {
 
 const CORE_DOCK: DockItem[] = [
   { id: 'ido', label: 'Path', icon: '⚡', path: '/app/ido' },
-  { id: 'ora', label: 'Aura', icon: '◈', path: '/app/ora' },
+  { id: 'aura', label: 'Aura', icon: '◈', path: '/app/aura' },
   { id: 'goals', label: 'Goals', icon: '🎯', path: '/app/goals' },
   { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },
 ];
@@ -39,7 +39,7 @@ const CORE_DOCK: DockItem[] = [
 const dockMenus: Partial<Record<ShellApp, DockItem[]>> = {
   home: CORE_DOCK,
   ido: CORE_DOCK,
-  ora: CORE_DOCK,
+  aura: CORE_DOCK,
   goals: CORE_DOCK,
   routines: CORE_DOCK,
   dao: CORE_DOCK,
@@ -228,7 +228,7 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
             <button
               key={item.id}
               type="button"
-              className={`connectome-dock__item ${active ? 'connectome-dock__item--active' : ''} ${item.id === 'ora' ? 'connectome-dock__item--ora' : ''}`}
+              className={`connectome-dock__item ${active ? 'connectome-dock__item--active' : ''} ${item.id === 'aura' ? 'connectome-dock__item--aura' : ''}`}
               onClick={() => handleDock(item)}
               aria-label={item.label}
             >

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
           'page-feed': ['./src/pages/FeedPage'],
           'page-goals': ['./src/pages/GoalsPage'],
           'page-journal': ['./src/pages/JournalPage'],
-          'page-ora': ['./src/pages/OraPage'],
+          'page-aura': ['./src/pages/AuraPage'],
           'page-dao': ['./src/pages/DAOPage'],
           'page-services': ['./src/pages/ServicesPage'],
           'page-profile': ['./src/pages/ProfilePage'],


### PR DESCRIPTION
## Scope

Full Ora → Aura rename in the web app. \`tsc && vite build\` is green.

## What changed

### Files & routes
- Page file: \`src/pages/OraPage.tsx\` → \`src/pages/AuraPage.tsx\`
- vite.config.ts \`page-ora\` chunk → \`page-aura\`
- Routes: canonical \`/app/aura\` (and \`/aura\` redirect to it). Legacy \`/app/ora\` and \`/ora\` are kept as React Router \`Navigate\` redirects to \`/app/aura\`.
- Shell: \`activeApp=\"ora\"\` → \`activeApp=\"aura\"\`; tab id \`'ora'\` → \`'aura'\`; \`dockMenus\` key updated

### Types
- \`AppId\` union: \`'ora'\` → \`'aura'\`
- \`ChatMessage\` / \`Message\` role: \`'user' | 'ora'\` → \`'user' | 'aura'\`
- \`MemoryFraming\` literal \`'ora_remembers'\` → \`'aura_remembers'\`

### API client
- All calls migrated from \`/api/ora/*\` → \`/api/aura/*\`
- Method \`getOraSelf\` → \`getAuraSelf\`
- Field names: \`ora_state\`, \`ora_reflection\`, \`ora_focus\`, \`ora_evaluation\`, \`ora_action\`, \`ora_response\`, \`ora_mission_statement\`, \`ora_nodes\`, \`paid_ora_nodes\` → all \`aura_*\`

### A/B experiments
- Experiment IDs: \`ora_greeting\` / \`ora_response_length\` / \`ora_proactive_suggestions\` → \`aura_*\` (matches backend)

### CSS
- All \`.ora-*\` class selectors → \`.aura-*\` (overlay, brain, badge, hero, stat, thought-card, etc.)
- Animation keyframes updated to match

### Docs
- \`README.md\`, \`docs/ONTOLOGY.md\`, \`docs/UX_FLOW.md\`, \`docs/DEVELOPER_MISSION.md\` swept

## Coordinated with

- **\`connectome-backend\` PR #77** — backend rename + DB migration + \`/api/ora/*\` alias middleware
- **\`atdao\` PR #9** — homepage CSS class names + \`/ora-thought\` → \`/aura-thought\`

These three PRs ship independently. Backend's middleware ensures any release-order combination works.

## Notes for review

- \`tsc && vite build\` is green
- All API calls use \`/api/aura/*\`. The deployed backend's middleware accepts both \`/api/ora/*\` and \`/api/aura/*\` so this PR can ship before the backend PR if needed.
- Legacy URL bookmarks like \`/app/ora\` or \`/ora\` continue to work via \`Navigate\` redirects.