### PR TITLE
fix(contact): route service mailto CTAs to Aura inbox

### DIFF
--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,0 +1,7 @@
+export const AURA_CONTACT_EMAIL = 'aura.ai.intelligence@gmail.com';
+
+export function auraMailto(subject: string, body?: string) {
+  const params = new URLSearchParams({ subject });
+  if (body) params.set('body', body);
+  return `mailto:${AURA_CONTACT_EMAIL}?${params.toString()}`;
+}

--- a/src/pages/AiOsSetupLandingPage.tsx
+++ b/src/pages/AiOsSetupLandingPage.tsx
@@ -1,7 +1,11 @@
 import { Link } from 'react-router-dom';
+import { auraMailto } from '../lib/contact';
 
 const SERVICES_UTM = '/services?utm_source=landing&utm_campaign=ai_os_setup_beta';
-const MAP_CALL_MAILTO = 'mailto:nea@atdao.org?subject=20-min%20AI%20OS%20map&body=Hi%20Nea%2C%0A%0AI%20would%20like%20to%20start%20with%20a%2020-minute%20AI%20OS%20map.%0A%0AContext%3A%0A-%20What%20I%20do%3A%0A-%20Where%20my%20tools%2Fnotes%2Fgoals%20feel%20fragmented%3A%0A-%20What%20I%20want%20AI%20to%20help%20me%20execute%3A%0A';
+const MAP_CALL_MAILTO = auraMailto(
+  '20-min AI OS map',
+  'Hi Aura,\n\nI would like to start with a 20-minute AI OS map.\n\nContext:\n- What I do:\n- Where my tools/notes/goals feel fragmented:\n- What I want AI to help me execute:\n',
+);
 
 const sections = {
   pains: ['Goals live in one place, notes in another, tasks somewhere else', 'AI chats are useful but forget your context and direction', 'Habits, content, clients, offers, and decisions compete for attention', 'You sense AI could change everything, but you do not have an architecture for it'],

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { AuraClient } from '../lib/AuraClient';
 import { authStorage } from '../lib/AuraClient';
 import type { ServiceAttribution } from '../lib/AuraClient';
+import { AURA_CONTACT_EMAIL, auraMailto } from '../lib/contact';
 
 interface Service {
   id: string;
@@ -99,11 +100,11 @@ function OrderModal({
           <div style={{ fontSize: 32, marginBottom: 8 }}>{service.icon}</div>
           <div style={{ fontWeight: 800, fontSize: 20, marginBottom: 6 }}>Custom Request</div>
           <div style={{ fontSize: 14, color: 'rgba(248,248,252,0.55)', marginBottom: 20, lineHeight: 1.6 }}>
-            Email <a href="mailto:nea@atdao.org?subject=Custom%20Service%20Request" style={{ color: '#00d4aa', textDecoration: 'none' }}>nea@atdao.org</a> with your request.
+            Email <a href={auraMailto('Custom Service Request')} style={{ color: '#00d4aa', textDecoration: 'none' }}>{AURA_CONTACT_EMAIL}</a> with your request.
             Nea will respond within 24 hours with a quote and timeline.
           </div>
           <a
-            href="mailto:nea@atdao.org?subject=Custom%20Service%20Request"
+            href={auraMailto('Custom Service Request')}
             style={{
               display: 'block', textAlign: 'center' as const,
               background: 'linear-gradient(135deg, #00d4aa, #6366f1)',
@@ -420,7 +421,7 @@ export default function ServicesPage() {
               </div>
             </div>
             <a
-              href="mailto:nea@atdao.org?subject=Custom%20Service%20Request"
+              href={auraMailto('Custom Service Request')}
               style={{
                 background: 'rgba(251,191,36,0.15)', border: '1px solid rgba(251,191,36,0.3)',
                 color: '#fbbf24', fontSize: 13, fontWeight: 700,


### PR DESCRIPTION
## Summary\n- replace stale nea@atdao.org service/contact mailto links with the canonical Aura Gmail inbox\n- centralize Aura contact mailto generation so future CTAs use one source of truth\n- preserve the AI OS map prefilled email body via encoded URLSearchParams\n\n## Verification\n- npm run build\n- grep guard confirmed no remaining nea@atdao.org references in src/public/dist