### PR TITLE
fix: add GitHub Pages fallbacks for public routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/create-spa-route-fallbacks.mjs",
     "preview": "vite preview",
     "deploy": "gh-pages -d dist"
   },

--- a/scripts/create-spa-route-fallbacks.mjs
+++ b/scripts/create-spa-route-fallbacks.mjs
@@ -1,0 +1,28 @@
+import { mkdirSync, copyFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const distDir = 'dist'
+const indexPath = join(distDir, 'index.html')
+
+// GitHub Pages returns HTTP 404 for browser-history routes unless a real file
+// exists at that path. Keep public/SEO landing routes directly fetchable so
+// they can be shared in public posts, crawled, and checked by link preview bots.
+const publicRoutes = [
+  'ai-os-setup',
+  'services',
+  'services/ai-os-setup',
+  'ai-os-human-flourishing',
+  'path-feed-momentum',
+]
+
+if (!existsSync(indexPath)) {
+  throw new Error(`Missing ${indexPath}; run this script after vite build`)
+}
+
+for (const route of publicRoutes) {
+  const routeDir = join(distDir, route)
+  mkdirSync(routeDir, { recursive: true })
+  copyFileSync(indexPath, join(routeDir, 'index.html'))
+}
+
+console.log(`Created GitHub Pages route fallbacks for ${publicRoutes.length} public routes.`)


### PR DESCRIPTION
## Summary\n- add a post-build route fallback script for public/SEO landing routes\n- make GitHub Pages serve real index files for shareable routes like /path-feed-momentum and /ai-os-human-flourishing\n- keep the existing 404 SPA fallback for non-public app routes\n\n## Growth/traffic impact\n- removes the HTTP 404 risk for owned public landing links before the next low-frequency public activation post\n- helps link preview bots and directory/review checks fetch public routes directly\n\n## Validation\n- npm run build\n- git diff --check\n- python3 scripts/guard_no_public_secrets.py\n- verified dist/path-feed-momentum/index.html and dist/ai-os-human-flourishing/index.html are generated