### PR TITLE
fix: scope experiment cache to authenticated user

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { authStorage, AuraClient } from '../lib/AuraClient';
+import { clearExperimentCache } from '../lib/useExperiment';
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -36,6 +37,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = async (email: string, password: string) => {
     const res = await AuraClient.login(email, password);
+    clearExperimentCache();
     authStorage.setAuth(res.access_token, res.user_id);
     setIsAuthenticated(true);
     setUserId(res.user_id);
@@ -43,6 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const register = async (email: string, password: string, displayName?: string) => {
     const res = await AuraClient.register(email, password, displayName);
+    clearExperimentCache();
     authStorage.setAuth(res.access_token, res.user_id);
     setIsAuthenticated(true);
     setUserId(res.user_id);
@@ -50,6 +53,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = () => {
     authStorage.clearAuth();
+    clearExperimentCache();
     setIsAuthenticated(false);
     setUserId(null);
     setProfile(null);

--- a/src/lib/useExperiment.ts
+++ b/src/lib/useExperiment.ts
@@ -19,9 +19,12 @@ interface ExperimentAssignments {
   [experiment: string]: string; // experiment_name -> variant_key
 }
 
-// Session-level cache — shared across all hook instances in the same page load
+// Session-level cache — shared across all hook instances for the same signed-in user.
+// Auth can change without a full reload, so keep the cache keyed by user id.
 let assignmentCache: ExperimentAssignments | null = null;
+let assignmentCacheUserId: string | null = null;
 let assignmentFetchPromise: Promise<ExperimentAssignments> | null = null;
+let assignmentFetchUserId: string | null = null;
 
 function getToken(): string {
   return localStorage.getItem(TOKEN_KEY) || '';
@@ -42,17 +45,23 @@ async function fetchAllAssignments(userId: string): Promise<ExperimentAssignment
 }
 
 async function getAssignments(userId: string): Promise<ExperimentAssignments> {
-  if (assignmentCache) return assignmentCache;
-  // Deduplicate concurrent fetches
-  if (!assignmentFetchPromise) {
+  if (assignmentCache && assignmentCacheUserId === userId) return assignmentCache;
+
+  // Deduplicate concurrent fetches only for the same user. If auth changes mid-page,
+  // start a fresh request so a previous account's variants cannot leak forward.
+  if (!assignmentFetchPromise || assignmentFetchUserId !== userId) {
+    assignmentFetchUserId = userId;
     assignmentFetchPromise = fetchAllAssignments(userId)
       .then((data) => {
         assignmentCache = data;
+        assignmentCacheUserId = userId;
         assignmentFetchPromise = null;
+        assignmentFetchUserId = null;
         return data;
       })
       .catch((err) => {
         assignmentFetchPromise = null;
+        assignmentFetchUserId = null;
         console.warn('[useExperiment] assignment fetch failed:', err);
         return {};
       });
@@ -90,7 +99,9 @@ async function trackExperimentEvent(
 /** Clear the session-level assignment cache (e.g. after login/logout). */
 export function clearExperimentCache(): void {
   assignmentCache = null;
+  assignmentCacheUserId = null;
   assignmentFetchPromise = null;
+  assignmentFetchUserId = null;
 }
 
 /**


### PR DESCRIPTION
## Summary\n- Key the in-page experiment assignment cache by signed-in user id\n- Clear experiment assignments/pending fetches on login, registration, and logout\n- Prevent stale A/B variants from leaking across account switches without requiring a hard reload\n\n## Verification\n- npm run build\n- python3 scripts/guard_no_public_secrets.py