### PR TITLE
feat: weave Aura recommendations into profile

### DIFF
--- a/src/components/AuraRecommendationStrip.tsx
+++ b/src/components/AuraRecommendationStrip.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export type AuraRecommendationDomain = 'iVive' | 'Eviva' | 'Aventi' | 'Rest' | string;
+
+export type AuraRecommendation = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  cta?: string;
+  domain?: AuraRecommendationDomain;
+  evidenceHint?: string;
+};
+
+const DOMAIN_CONFIG: Record<string, { emoji: string; color: string; label: string }> = {
+  iVive: { emoji: '🌱', color: '#10b981', label: 'Self / capacity' },
+  Eviva: { emoji: '🌊', color: '#6366f1', label: 'Contribution' },
+  Aventi: { emoji: '🚀', color: '#f59e0b', label: 'Experience' },
+};
+
+function domainConfig(domain?: AuraRecommendationDomain) {
+  const normalized = domain === 'Rest' ? 'iVive' : domain;
+  return DOMAIN_CONFIG[normalized || ''] || { emoji: '◈', color: '#00d4aa', label: 'Path' };
+}
+
+export function AuraRecommendationStrip({
+  recommendation,
+  onAction,
+  actionLabel,
+}: {
+  recommendation: AuraRecommendation;
+  onAction?: () => void;
+  actionLabel?: string;
+}) {
+  const cfg = domainConfig(recommendation.domain);
+  const cta = actionLabel || recommendation.cta;
+
+  return (
+    <section style={{ position: 'relative', overflow: 'hidden', border: `1px solid ${cfg.color}24`, background: 'linear-gradient(135deg, rgba(255,255,255,0.055), rgba(0,212,170,0.045))', borderRadius: 26, padding: 16, margin: '0 0 16px' }}>
+      <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(circle at 12% 0%, ${cfg.color}1f, transparent 42%)`, pointerEvents: 'none' }} />
+      <div style={{ position: 'relative', display: 'grid', gap: 12 }}>
+        <div>
+          <div style={{ color: cfg.color, fontSize: 11, fontWeight: 950, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 7 }}>{cfg.emoji} {recommendation.eyebrow}</div>
+          <h2 style={{ color: '#f8f8fc', fontSize: 20, letterSpacing: -0.55, lineHeight: 1.15, margin: 0 }}>{recommendation.title}</h2>
+          <p style={{ color: 'rgba(248,248,252,0.62)', fontSize: 13, lineHeight: 1.55, margin: '8px 0 0' }}>{recommendation.body}</p>
+          {recommendation.evidenceHint && (
+            <div style={{ color: 'rgba(248,248,252,0.42)', fontSize: 11, lineHeight: 1.45, marginTop: 8 }}>{recommendation.evidenceHint}</div>
+          )}
+        </div>
+        {cta && onAction && (
+          <button onClick={onAction} style={{ justifySelf: 'start', border: `1px solid ${cfg.color}40`, background: `${cfg.color}18`, color: '#dffcf6', borderRadius: 999, padding: '10px 13px', fontSize: 12, fontWeight: 950, cursor: 'pointer' }}>
+            {cta} →
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/GoalsPage.tsx
+++ b/src/pages/GoalsPage.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../components/Toast';
 import { useExperiment } from '../lib/useExperiment';
 import GoalClarifyModal from '../components/GoalClarifyModal';
 import { PathLimitSheet } from '../components/PathLimitSheet';
+import { AuraRecommendationStrip, AuraRecommendation } from '../components/AuraRecommendationStrip';
 
 type Lens = 'active' | 'paths' | 'saved' | 'done' | 'all';
 
@@ -21,13 +22,6 @@ const STARTERS = [
   { title: 'Turn a vague desire into a real path', tag: 'clarify', domain: 'iVive' },
 ];
 
-type GoalSeed = {
-  eyebrow: string;
-  title: string;
-  body: string;
-  cta: string;
-  domain: string;
-};
 
 function domainConfig(domain?: string) {
   const normalized = domain === 'Rest' ? 'iVive' : domain; // legacy Rest maps into iVive; Rest is an iVive aspect.
@@ -58,7 +52,7 @@ function stateCopy(state: string) {
   return 'Achieved';
 }
 
-function auraGoalSeed(goals: Goal[]): GoalSeed {
+function auraGoalSeed(goals: Goal[]): AuraRecommendation {
   const active = goals.filter((g) => g.status === 'active');
   const unmapped = active.filter((g) => !g.steps?.length);
   const moving = active.filter((g) => progressFor(g) > 0 && progressFor(g) < 1);
@@ -196,22 +190,12 @@ function WeeklyRecapCard() {
 
 function AuraGoalSeedCard({ goals, onClarify }: { goals: Goal[]; onClarify: (title: string) => void }) {
   const seed = auraGoalSeed(goals);
-  const cfg = domainConfig(seed.domain);
-
   return (
-    <section style={{ position: 'relative', overflow: 'hidden', border: `1px solid ${cfg.color}24`, background: 'linear-gradient(135deg, rgba(255,255,255,0.055), rgba(0,212,170,0.045))', borderRadius: 26, padding: 16, margin: '0 0 16px' }}>
-      <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(circle at 12% 0%, ${cfg.color}1f, transparent 42%)`, pointerEvents: 'none' }} />
-      <div style={{ position: 'relative', display: 'grid', gap: 12 }}>
-        <div>
-          <div style={{ color: cfg.color, fontSize: 11, fontWeight: 950, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 7 }}>{cfg.emoji} {seed.eyebrow}</div>
-          <h2 style={{ color: '#f8f8fc', fontSize: 20, letterSpacing: -0.55, lineHeight: 1.15, margin: 0 }}>{seed.title}</h2>
-          <p style={{ color: 'rgba(248,248,252,0.62)', fontSize: 13, lineHeight: 1.55, margin: '8px 0 0' }}>{seed.body}</p>
-        </div>
-        <button onClick={() => onClarify(seed.cta)} style={{ justifySelf: 'start', border: `1px solid ${cfg.color}40`, background: `${cfg.color}18`, color: '#dffcf6', borderRadius: 999, padding: '10px 13px', fontSize: 12, fontWeight: 950 }}>
-          Seed this with Aura →
-        </button>
-      </div>
-    </section>
+    <AuraRecommendationStrip
+      recommendation={{ ...seed, evidenceHint: 'This recommendation is shown inside Goals so Aura guidance feels woven through the OS, not locked in the feed.' }}
+      actionLabel="Seed this with Aura"
+      onAction={() => onClarify(seed.cta || seed.title)}
+    />
   );
 }
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -6,6 +6,7 @@ import { useExperiment } from '../lib/useExperiment';
 import { StreakBadge } from '../components/StreakBadge';
 import { billingCancelUrl, billingSuccessUrl } from '../lib/checkoutUrls';
 import { UpgradePanel } from '../components/UpgradePanel';
+import { AuraRecommendationStrip, AuraRecommendation } from '../components/AuraRecommendationStrip';
 
 const EXPERIMENT_ID = 'primary_landing_v1';
 const VARIANTS = ['A', 'B', 'C', 'D'] as const;
@@ -33,6 +34,42 @@ const DEFAULT_VALUE_SCORES: Record<(typeof TOP_LEVEL_VALUES)[number], number> = 
   abundance: 6,
   adventure: 7,
 };
+
+function profileAuraRecommendation(profile: any, tier: string): AuraRecommendation {
+  const topValues = Object.entries(profile?.profile?.value_weights || profile?.profile?.valueWeights || DEFAULT_VALUE_SCORES)
+    .sort((a, b) => Number(b[1]) - Number(a[1]))
+    .slice(0, 2)
+    .map(([value]) => value);
+
+  if (!profile?.profile?.now_vector_prompt && !profile?.profile?.later_vector_prompt) {
+    return {
+      eyebrow: 'Profile signal Aura needs',
+      title: 'Give Aura a current-state and future-state vector',
+      body: 'Your profile already stores values, tier, Drive, and travel signals. Add one current path signal and one future-facing signal so recommendations across Goals and iDo have better context.',
+      cta: 'Tune recommendation vectors',
+      domain: 'iVive',
+      evidenceHint: 'These vectors become reusable context for the graph instead of another isolated profile setting.',
+    };
+  }
+
+  if (tier === 'free') {
+    return {
+      eyebrow: 'Explorer path preview',
+      title: 'Turn profile context into richer Aura guidance',
+      body: `Aura can use your ${topValues.join(' + ') || 'value'} signals to shape next nodes, evidence prompts, and surfaced recommendations as your graph grows.`,
+      cta: 'See Explorer unlocks',
+      domain: 'Aventi',
+    };
+  }
+
+  return {
+    eyebrow: 'Personal OS calibration',
+    title: 'Keep your profile as the source of truth for recommendations',
+    body: `Aura is currently weighted toward ${topValues.join(' + ') || 'your values'}. Revisit these when your season changes so every surface recommends from the right state.`,
+    cta: 'Review value compass',
+    domain: 'Eviva',
+  };
+}
 
 const getStoredAdminToken = () => localStorage.getItem('admin_token')?.trim() || '';
 const getAdminHeaders = () => {
@@ -608,6 +645,22 @@ export default function ProfilePage() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
           {/* ── Streak + Milestones + Badges ── */}
           <StreakBadge />
+
+          <AuraRecommendationStrip
+            recommendation={profileAuraRecommendation(profile, tier)}
+            onAction={() => {
+              const recommendation = profileAuraRecommendation(profile, tier);
+              if (recommendation.cta === 'Tune recommendation vectors') {
+                setVectorsOpen(true);
+                return;
+              }
+              if (recommendation.cta === 'See Explorer unlocks') {
+                setShowUpgradePanel(true);
+                return;
+              }
+              setCompassOpen(true);
+            }}
+          />
 
           {/* Google Drive — compact folded control */}
           <div style={{ background: '#12121a', border: `1px solid ${driveStatus?.connected ? 'rgba(52,211,153,0.26)' : 'rgba(255,255,255,0.07)'}`, borderRadius: 14, overflow: 'hidden' }}>


### PR DESCRIPTION
## Summary
- Adds a reusable AuraRecommendationStrip for contextual Aura guidance outside the feed.
- Reuses the strip on Goals while preserving the existing clarify action.
- Adds a Profile recommendation that routes users into vector tuning, Explorer upgrade, or value compass review based on their profile state.

## Why
Connectome/Aura should feel like a meta-app / AI OS where guidance appears inside the surfaces people already use, not only as a destination feed.

## Testing
- npm run build
- python3 scripts/guard_no_public_secrets.py

Refs #33