### PR TITLE
feat: add discovery shortcuts

### DIFF
--- a/docs/UX_FLOW.md
+++ b/docs/UX_FLOW.md
@@ -164,7 +164,8 @@ Primary feed responses are graph-learning signals:
 ### Authenticated app
 
 - `/app` — Home/orientation screen.
-- `/app/ido` — one-action feed/discovery.
+- `/app/discovery` / `/app/discovery-agent` — one-action feed/discovery (canonical user-facing route).
+- `/app/ido` — legacy path to the same discovery surface.
 - `/app/goals` — goals and Aura clarification.
 - `/app/routines` — routines and habits.
 - `/app/dao` — DAO, CP, proposals, governance, contribution overview.
@@ -179,7 +180,7 @@ Primary feed responses are graph-learning signals:
 ### Backward-compatible redirects
 
 - `/home` → `/app`
-- `/feed`, `/discover`, `/journal` → `/app/ido`
+- `/feed`, `/discover`, `/discovery`, `/discovery-agent`, `/journal` → discovery surface
 - `/goals` → `/app/goals`
 - `/routines` → `/app/routines`
 - `/dao` → `/app/dao`

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -163,7 +163,9 @@ function App() {
           {/* AIOS app routes */}
           <Route path="/app" element={<ShellRoute activeApp="home"><ConnectomeHome /></ShellRoute>} />
           <Route path="/app/ido" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
-          <Route path="/app/future" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/app/discovery" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
+          <Route path="/app/discovery-agent" element={<ShellRoute activeApp="ido"><FeedPage /></ShellRoute>} />
+          <Route path="/app/future" element={<Navigate to="/app/discovery" replace />} />
           <Route path="/app/aura" element={<ShellRoute activeApp="aura"><AuraPage /></ShellRoute>} />
           <Route path="/app/aura" element={<Navigate to="/app/aura" replace />} />
           <Route path="/app/goals" element={<ShellRoute activeApp="goals"><GoalsPage /></ShellRoute>} />
@@ -172,7 +174,7 @@ function App() {
           <Route path="/app/contribute" element={<ShellRoute activeApp="contribute"><ContributePage /></ShellRoute>} />
           <Route path="/app/profile" element={<ShellRoute activeApp="profile"><ProfilePage /></ShellRoute>} />
           <Route path="/app/billing/success" element={<ShellRoute activeApp="profile"><PaymentSuccessPage /></ShellRoute>} />
-          <Route path="/app/journal" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/app/journal" element={<Navigate to="/app/discovery" replace />} />
           <Route path="/app/services" element={<ShellRoute activeApp="services"><ServicesPage /></ShellRoute>} />
           <Route path="/services" element={<ServicesPage />} />
           <Route path="/ai-os-setup" element={<AiOsSetupLandingPage />} />
@@ -188,11 +190,13 @@ function App() {
 
           {/* Backward-compatible redirects */}
           <Route path="/home" element={<Navigate to="/app" replace />} />
-          <Route path="/feed" element={<Navigate to="/app/ido" replace />} />
-          <Route path="/discover" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/feed" element={<Navigate to="/app/discovery" replace />} />
+          <Route path="/discover" element={<Navigate to="/app/discovery" replace />} />
+          <Route path="/discovery" element={<Navigate to="/app/discovery" replace />} />
+          <Route path="/discovery-agent" element={<Navigate to="/app/discovery-agent" replace />} />
           <Route path="/goals" element={<Navigate to="/app/goals" replace />} />
           <Route path="/routines" element={<Navigate to="/app/routines" replace />} />
-          <Route path="/journal" element={<Navigate to="/app/ido" replace />} />
+          <Route path="/journal" element={<Navigate to="/app/discovery" replace />} />
           <Route path="/aura" element={<Navigate to="/app/aura" replace />} />
           <Route path="/ora" element={<Navigate to="/app/aura" replace />} />
           <Route path="/dao" element={<Navigate to="/app/dao" replace />} />

--- a/src/pages/ConnectomeHome.tsx
+++ b/src/pages/ConnectomeHome.tsx
@@ -5,7 +5,7 @@ import { PageHero, SectionCard } from '../components/design';
 
 const nextSignals = [
   { label: 'Guided path', title: 'Turn a desire into a concrete next step', path: '/app/goals' },
-  { label: 'Discovery feed', title: 'Browse one doable action at a time', path: '/app/ido' },
+  { label: 'Discovery feed', title: 'Browse one doable action at a time', path: '/app/discovery' },
   { label: 'Community', title: 'Contribute to the ecosystem and earn CP', path: '/app/dao' },
 ];
 
@@ -84,13 +84,13 @@ export default function ConnectomeHome() {
 
         <button
           type="button"
-          onClick={() => navigate('/app/ido')}
+          onClick={() => navigate('/app/discovery')}
           style={{ ...actionPanel, padding: 24, color: '#f8f8fc', textAlign: 'left', cursor: 'pointer' }}
         >
           <div style={{ color: '#f4c26b', fontSize: 12, fontWeight: 900, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 12 }}>I don’t know what I want to do</div>
           <h2 style={{ margin: '0 0 10px', fontSize: 28, letterSpacing: -0.7 }}>Begin your path</h2>
           <p style={{ margin: 0, color: 'rgba(248,248,252,0.62)', lineHeight: 1.6 }}>Open the discovery feed and choose, save, skip, or act on one useful possibility at a time.</p>
-          <div style={{ marginTop: 18, color: '#f4c26b', fontWeight: 900 }}>Open Path Feed →</div>
+          <div style={{ marginTop: 18, color: '#f4c26b', fontWeight: 900 }}>Open Discovery →</div>
         </button>
       </section>
 

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -17,7 +17,7 @@ interface ConnectomeShellProps {
 
 function appLabel(appId: ShellApp) {
   if (appId === 'home') return 'Aura';
-  if (appId === 'ido') return 'Path';
+  if (appId === 'ido') return 'Discover';
   return appById(appId)?.name || 'Aura';
 }
 
@@ -30,7 +30,7 @@ type DockItem = {
 };
 
 const CORE_DOCK: DockItem[] = [
-  { id: 'ido', label: 'Path', icon: '⚡', path: '/app/ido' },
+  { id: 'ido', label: 'Discover', icon: '⚡', path: '/app/discovery' },
   { id: 'aura', label: 'Aura', icon: '◈', path: '/app/aura' },
   { id: 'goals', label: 'Goals', icon: '🎯', path: '/app/goals' },
   { id: 'profile', label: 'Profile', icon: '👤', path: '/app/profile' },


### PR DESCRIPTION
## Summary
- add canonical /app/discovery and /app/discovery-agent routes for the discovery feed
- rename the bottom dock entry from Path to Discover and route it directly to /app/discovery
- update home CTAs and UX route docs to use the discovery shortcut

Closes #93

## Verification
- npm run build
- python3 scripts/guard_no_public_secrets.py