### PR TITLE
Seed feedback context trail for Aura learning

### DIFF
--- a/src/components/AuraRecommendationStrip.tsx
+++ b/src/components/AuraRecommendationStrip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { recordFeedbackAction, setActiveFeedbackContext } from '../lib/feedbackContext';
 
 export type AuraRecommendationDomain = 'iVive' | 'Eviva' | 'Aventi' | 'Rest' | string;
 
@@ -55,13 +56,22 @@ export function AuraRecommendationStrip({
         metadata: recommendation.metadata || {},
         updated_at: new Date().toISOString(),
       };
-      try {
-        window.localStorage.setItem('aura_active_feedback_context', JSON.stringify({
-          ...eventPayload,
-          surface: `recommendation:${surface}`,
-          card_type: 'aura_recommendation',
-        }));
-      } catch {}
+      const feedbackContext = {
+        ...eventPayload,
+        surface: `recommendation:${surface}`,
+        card_type: 'aura_recommendation',
+      };
+      setActiveFeedbackContext(feedbackContext);
+      recordFeedbackAction({
+        type: 'recommendation_cta',
+        route: eventPayload.route,
+        title: recommendation.title,
+        cta,
+        domain: recommendation.domain || null,
+        node_id: recommendation.nodeId || null,
+        tracking_id: recommendation.trackingId || null,
+        source: recommendation.source || 'aura_recommendation_strip',
+      });
       window.dispatchEvent(new CustomEvent('connectome:aura-recommendation-action', { detail: eventPayload }));
     }
     onAction?.();

--- a/src/components/GlobalFeedbackButton.tsx
+++ b/src/components/GlobalFeedbackButton.tsx
@@ -3,6 +3,7 @@ import html2canvas from 'html2canvas';
 import { AuraClient, GlobalFeedbackPayload } from '../lib/AuraClient';
 import CPExplainerModal from './CPExplainerModal';
 import { useToast } from './Toast';
+import { buildFeedbackContextSnapshot } from '../lib/feedbackContext';
 
 const CATEGORIES: GlobalFeedbackPayload['category'][] = ['Bad Card/Node', 'Malfunction', 'Bug', 'Confusing', 'Idea', 'Design', 'Praise', 'Other'];
 
@@ -83,13 +84,7 @@ export default function GlobalFeedbackButton({ inlineMode = false, inlineTrigger
     setError(null);
     try {
       let screenshot: string | null = null;
-      let feedbackContext: Record<string, any> | null = null;
-      try {
-        const rawContext = localStorage.getItem('aura_active_feedback_context');
-        feedbackContext = rawContext ? JSON.parse(rawContext) : null;
-      } catch {
-        feedbackContext = null;
-      }
+      const feedbackContext = buildFeedbackContextSnapshot();
       const metadata: Record<string, any> = {
         viewport: { width: window.innerWidth, height: window.innerHeight },
         userAgent: navigator.userAgent,

--- a/src/lib/feedbackContext.ts
+++ b/src/lib/feedbackContext.ts
@@ -1,0 +1,74 @@
+export const ACTIVE_FEEDBACK_CONTEXT_KEY = 'aura_active_feedback_context';
+export const FEEDBACK_ROUTE_TRAIL_KEY = 'aura_feedback_route_trail';
+export const FEEDBACK_ACTION_TRAIL_KEY = 'aura_feedback_action_trail';
+
+const MAX_TRAIL_ITEMS = 8;
+
+function readJsonArray(key: string): Record<string, any>[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) || '[]');
+    return Array.isArray(parsed) ? parsed.filter((item) => item && typeof item === 'object') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeJsonArray(key: string, items: Record<string, any>[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(items.slice(-MAX_TRAIL_ITEMS)));
+  } catch {
+    // Feedback context is best-effort only; never block the UI.
+  }
+}
+
+export function appendFeedbackTrail(key: string, entry: Record<string, any>) {
+  const trail = readJsonArray(key);
+  writeJsonArray(key, [...trail, entry]);
+}
+
+export function recordFeedbackRoute(route: string, app?: string) {
+  const existingTrail = readJsonArray(FEEDBACK_ROUTE_TRAIL_KEY);
+  const last = existingTrail[existingTrail.length - 1];
+  if (last?.route === route) return;
+  appendFeedbackTrail(FEEDBACK_ROUTE_TRAIL_KEY, {
+    route,
+    app: app || null,
+    title: typeof document !== 'undefined' ? document.title : null,
+    visited_at: new Date().toISOString(),
+  });
+}
+
+export function recordFeedbackAction(entry: Record<string, any>) {
+  appendFeedbackTrail(FEEDBACK_ACTION_TRAIL_KEY, {
+    ...entry,
+    happened_at: new Date().toISOString(),
+  });
+}
+
+export function setActiveFeedbackContext(context: Record<string, any>) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ACTIVE_FEEDBACK_CONTEXT_KEY, JSON.stringify(context));
+  } catch {
+    // Best-effort only.
+  }
+}
+
+export function buildFeedbackContextSnapshot() {
+  if (typeof window === 'undefined') return null;
+  let active: Record<string, any> | null = null;
+  try {
+    const raw = window.localStorage.getItem(ACTIVE_FEEDBACK_CONTEXT_KEY);
+    active = raw ? JSON.parse(raw) : null;
+  } catch {
+    active = null;
+  }
+
+  return {
+    active,
+    route_trail: readJsonArray(FEEDBACK_ROUTE_TRAIL_KEY),
+    action_trail: readJsonArray(FEEDBACK_ACTION_TRAIL_KEY),
+  };
+}

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -7,6 +7,7 @@ import AuraOverlay from './AuraOverlay';
 import GlobalFeedbackButton from '../components/GlobalFeedbackButton';
 import { appById, type AppId } from '../runtime/ontology';
 import { AuraClient } from '../lib/AuraClient';
+import { recordFeedbackRoute } from '../lib/feedbackContext';
 
 type ShellApp = Exclude<AppId, 'aventi' | 'ivive' | 'eviva'>;
 
@@ -179,6 +180,10 @@ export default function ConnectomeShell({ children, activeApp = 'home' }: Connec
       })
       .catch(() => setLocationPromptOpen(true));
   }, [profile]);
+
+  useEffect(() => {
+    recordFeedbackRoute(`${location.pathname}${location.search}${location.hash}`, activeApp);
+  }, [activeApp, location.pathname, location.search, location.hash]);
 
   const dockItems = dockMenus[activeApp] || dockMenus.home || [];
 


### PR DESCRIPTION
## Summary\n- add a small feedback context helper that keeps a bounded local route/action trail\n- record shell route visits and Aura recommendation CTA clicks as learning/debug context\n- include active context plus recent trails in global feedback metadata so reports explain what led to the issue\n\n## Why\nThis gives Aura/Connectome richer product intelligence from real user behaviour without adding new backend tables or collecting secrets. It is a small step toward developer onboarding/product analytics (#19) and better bad-card/node diagnosis.\n\n## Verification\n- npm run build\n- python3 scripts/guard_no_public_secrets.py