### PR TITLE
feat: add local developer funnel diagnostics

### DIFF
--- a/docs/DEVELOPER_ONBOARDING_ANALYTICS.md
+++ b/docs/DEVELOPER_ONBOARDING_ANALYTICS.md
@@ -1,13 +1,13 @@
 # Developer onboarding analytics
 
-The Contribute surface records a small authenticated funnel through the existing A/B event pipeline.
+The Contribute surface records a small privacy-light funnel through the existing A/B event pipeline, with a local browser buffer for unauthenticated/local inspection.
 
 ## Funnel identity
 
 - `experiment_id`: `developer_onboarding_funnel`
 - `variant`: `contribute_page_v1`
 
-Telemetry is best-effort and silent: if the user is signed out, local dev has no API, Redis is unavailable, or the request fails, the UI keeps working.
+Telemetry is best-effort and silent: if the user is signed out, local dev has no API, Redis is unavailable, or the request fails, the UI keeps working. Every event is also written to a capped local browser ring buffer so the funnel remains inspectable before auth/backend capture is available.
 
 ## Events
 
@@ -15,6 +15,7 @@ Telemetry is best-effort and silent: if the user is signed out, local dev has no
 - `cp_explainer_opened`
 - `cp_issue_list_clicked`
 - `web_repo_clicked`
+- `backend_repo_clicked`
 - `community_clicked`
 - `github_connect_clicked`
 - `contribution_type_selected`
@@ -37,4 +38,18 @@ The backend stores events under Redis keys shaped like:
 ab:events:developer_onboarding_funnel:contribute_page_v1
 ```
 
-Do not add personal data, PR contents, issue contents, or free-form user text to these events. Event names and numeric values are enough for this funnel.
+For local or unauthenticated browser inspection, open DevTools on the Contribute page and run:
+
+```js
+window.logConnectomeDeveloperOnboardingEvents()
+```
+
+or retrieve the raw array with:
+
+```js
+window.connectomeDeveloperOnboardingEvents()
+```
+
+The local ring buffer is stored at `localStorage.connectome_developer_onboarding_events` and keeps the latest 50 events.
+
+Do not add personal data, PR contents, issue contents, or free-form user text to these events. Event names, numeric values, timestamps, and route paths are enough for this funnel.

--- a/src/lib/developerOnboardingAnalytics.ts
+++ b/src/lib/developerOnboardingAnalytics.ts
@@ -3,12 +3,15 @@ import { API_URL } from './config';
 const TOKEN_KEY = 'connectome_token';
 const EXPERIMENT_ID = 'developer_onboarding_funnel';
 const VARIANT = 'contribute_page_v1';
+const LOCAL_EVENT_KEY = 'connectome_developer_onboarding_events';
+const MAX_LOCAL_EVENTS = 50;
 
 export type DeveloperOnboardingEvent =
   | 'contribute_page_viewed'
   | 'cp_explainer_opened'
   | 'cp_issue_list_clicked'
   | 'web_repo_clicked'
+  | 'backend_repo_clicked'
   | 'community_clicked'
   | 'github_connect_clicked'
   | 'contribution_type_selected'
@@ -17,7 +20,63 @@ export type DeveloperOnboardingEvent =
   | 'contribution_submit_succeeded'
   | 'contribution_submit_failed';
 
+export type DeveloperOnboardingLocalEvent = {
+  experiment_id: typeof EXPERIMENT_ID;
+  variant: typeof VARIANT;
+  event_type: DeveloperOnboardingEvent;
+  value: number;
+  created_at: string;
+  path: string;
+};
+
+function readLocalEvents(): DeveloperOnboardingLocalEvent[] {
+  try {
+    const raw = localStorage.getItem(LOCAL_EVENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item) => item?.event_type && item?.created_at) : [];
+  } catch {
+    return [];
+  }
+}
+
+function storeLocalEvent(eventType: DeveloperOnboardingEvent, value: number): void {
+  const event: DeveloperOnboardingLocalEvent = {
+    experiment_id: EXPERIMENT_ID,
+    variant: VARIANT,
+    event_type: eventType,
+    value,
+    created_at: new Date().toISOString(),
+    path: window.location.pathname,
+  };
+
+  try {
+    const events = [...readLocalEvents(), event].slice(-MAX_LOCAL_EVENTS);
+    localStorage.setItem(LOCAL_EVENT_KEY, JSON.stringify(events));
+  } catch {
+    // Local diagnostics should never block contribution flows.
+  }
+}
+
+export function getDeveloperOnboardingEvents(): DeveloperOnboardingLocalEvent[] {
+  return readLocalEvents();
+}
+
+export function logDeveloperOnboardingEvents(): DeveloperOnboardingLocalEvent[] {
+  const events = getDeveloperOnboardingEvents();
+  if (typeof console.table === 'function') console.table(events);
+  else console.log(events);
+  return events;
+}
+
+if (typeof window !== 'undefined') {
+  (window as Window & { connectomeDeveloperOnboardingEvents?: typeof getDeveloperOnboardingEvents; logConnectomeDeveloperOnboardingEvents?: typeof logDeveloperOnboardingEvents }).connectomeDeveloperOnboardingEvents = getDeveloperOnboardingEvents;
+  (window as Window & { connectomeDeveloperOnboardingEvents?: typeof getDeveloperOnboardingEvents; logConnectomeDeveloperOnboardingEvents?: typeof logDeveloperOnboardingEvents }).logConnectomeDeveloperOnboardingEvents = logDeveloperOnboardingEvents;
+}
+
 export function trackDeveloperOnboardingEvent(eventType: DeveloperOnboardingEvent, value = 1): void {
+  storeLocalEvent(eventType, value);
+
   const token = localStorage.getItem(TOKEN_KEY);
   if (!token) return;
 

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -200,6 +200,7 @@ export default function ContributePage() {
           </div>
           <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
             <PrimaryCTA href="https://github.com/AvielCarlos/connectome-backend/issues" target="_blank" rel="noreferrer" onClick={() => trackDeveloperOnboardingEvent('cp_issue_list_clicked')}>Browse CP issues →</PrimaryCTA>
+            <PrimaryCTA href="https://github.com/AvielCarlos/connectome-backend" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('backend_repo_clicked')}>View backend repo</PrimaryCTA>
             <PrimaryCTA href="https://github.com/AvielCarlos/connectome-web" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('web_repo_clicked')}>View web repo</PrimaryCTA>
             <PrimaryCTA href="https://t.me/ascensiontechai" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('community_clicked')}>Join community</PrimaryCTA>
           </div>


### PR DESCRIPTION
## Summary

Adds a privacy-light local diagnostics buffer for the developer onboarding funnel so Contribute page events are inspectable even before auth/backend analytics are connected.

## Changes

- Store the latest 50 developer onboarding events in localStorage for local/unauthenticated inspection.
- Expose browser console helpers: `window.logConnectomeDeveloperOnboardingEvents()` and `window.connectomeDeveloperOnboardingEvents()`.
- Track backend repo CTA clicks separately and document production + local inspection paths.

## Testing

- `npm run build`
- `python3 scripts/guard_no_public_secrets.py`

Fixes AvielCarlos/connectome-web#19