### PR TITLE
Add daily AI check-in landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Useful first actions:
 - Try the app: https://avielcarlos.github.io/connectome-web/
 - Read concrete Path Feed examples: https://avielcarlos.github.io/connectome-web/path-feed-examples/
 - Read the return-loop proof page: https://avielcarlos.github.io/connectome-web/path-feed-return-loop/
+- Try the daily AI check-in landing path: https://avielcarlos.github.io/connectome-web/daily-ai-check-in/
 - Read the builder invitation and first-PR path: https://avielcarlos.github.io/connectome-web/connectome-builders/
 - Search discovery files: https://avielcarlos.github.io/connectome-web/sitemap.xml and https://avielcarlos.github.io/connectome-web/robots.txt
 - Open the Path Feed and give feedback on confusing or useful cards.

--- a/docs/DEVELOPER_ONBOARDING_ANALYTICS.md
+++ b/docs/DEVELOPER_ONBOARDING_ANALYTICS.md
@@ -1,13 +1,13 @@
 # Developer onboarding analytics
 
-The Contribute surface records a small authenticated funnel through the existing A/B event pipeline.
+The Contribute surface records a small privacy-light funnel through the existing A/B event pipeline, with a local browser buffer for unauthenticated/local inspection.
 
 ## Funnel identity
 
 - `experiment_id`: `developer_onboarding_funnel`
 - `variant`: `contribute_page_v1`
 
-Telemetry is best-effort and silent: if the user is signed out, local dev has no API, Redis is unavailable, or the request fails, the UI keeps working.
+Telemetry is best-effort and silent: if the user is signed out, local dev has no API, Redis is unavailable, or the request fails, the UI keeps working. Every event is also written to a capped local browser ring buffer so the funnel remains inspectable before auth/backend capture is available.
 
 ## Events
 
@@ -15,6 +15,7 @@ Telemetry is best-effort and silent: if the user is signed out, local dev has no
 - `cp_explainer_opened`
 - `cp_issue_list_clicked`
 - `web_repo_clicked`
+- `backend_repo_clicked`
 - `community_clicked`
 - `github_connect_clicked`
 - `contribution_type_selected`
@@ -37,4 +38,18 @@ The backend stores events under Redis keys shaped like:
 ab:events:developer_onboarding_funnel:contribute_page_v1
 ```
 
-Do not add personal data, PR contents, issue contents, or free-form user text to these events. Event names and numeric values are enough for this funnel.
+For local or unauthenticated browser inspection, open DevTools on the Contribute page and run:
+
+```js
+window.logConnectomeDeveloperOnboardingEvents()
+```
+
+or retrieve the raw array with:
+
+```js
+window.connectomeDeveloperOnboardingEvents()
+```
+
+The local ring buffer is stored at `localStorage.connectome_developer_onboarding_events` and keeps the latest 50 events.
+
+Do not add personal data, PR contents, issue contents, or free-form user text to these events. Event names, numeric values, timestamps, and route paths are enough for this funnel.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,6 +25,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://avielcarlos.github.io/connectome-web/daily-ai-check-in/</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://avielcarlos.github.io/connectome-web/connectome-builders/</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>

--- a/scripts/create-spa-route-fallbacks.mjs
+++ b/scripts/create-spa-route-fallbacks.mjs
@@ -15,6 +15,7 @@ const publicRoutes = [
   'path-feed-momentum',
   'path-feed-examples',
   'path-feed-return-loop',
+  'daily-ai-check-in',
   'connectome-builders',
 ]
 

--- a/src/lib/developerOnboardingAnalytics.ts
+++ b/src/lib/developerOnboardingAnalytics.ts
@@ -3,12 +3,15 @@ import { API_URL } from './config';
 const TOKEN_KEY = 'connectome_token';
 const EXPERIMENT_ID = 'developer_onboarding_funnel';
 const VARIANT = 'contribute_page_v1';
+const LOCAL_EVENT_KEY = 'connectome_developer_onboarding_events';
+const MAX_LOCAL_EVENTS = 50;
 
 export type DeveloperOnboardingEvent =
   | 'contribute_page_viewed'
   | 'cp_explainer_opened'
   | 'cp_issue_list_clicked'
   | 'web_repo_clicked'
+  | 'backend_repo_clicked'
   | 'community_clicked'
   | 'github_connect_clicked'
   | 'contribution_type_selected'
@@ -17,7 +20,63 @@ export type DeveloperOnboardingEvent =
   | 'contribution_submit_succeeded'
   | 'contribution_submit_failed';
 
+export type DeveloperOnboardingLocalEvent = {
+  experiment_id: typeof EXPERIMENT_ID;
+  variant: typeof VARIANT;
+  event_type: DeveloperOnboardingEvent;
+  value: number;
+  created_at: string;
+  path: string;
+};
+
+function readLocalEvents(): DeveloperOnboardingLocalEvent[] {
+  try {
+    const raw = localStorage.getItem(LOCAL_EVENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item) => item?.event_type && item?.created_at) : [];
+  } catch {
+    return [];
+  }
+}
+
+function storeLocalEvent(eventType: DeveloperOnboardingEvent, value: number): void {
+  const event: DeveloperOnboardingLocalEvent = {
+    experiment_id: EXPERIMENT_ID,
+    variant: VARIANT,
+    event_type: eventType,
+    value,
+    created_at: new Date().toISOString(),
+    path: window.location.pathname,
+  };
+
+  try {
+    const events = [...readLocalEvents(), event].slice(-MAX_LOCAL_EVENTS);
+    localStorage.setItem(LOCAL_EVENT_KEY, JSON.stringify(events));
+  } catch {
+    // Local diagnostics should never block contribution flows.
+  }
+}
+
+export function getDeveloperOnboardingEvents(): DeveloperOnboardingLocalEvent[] {
+  return readLocalEvents();
+}
+
+export function logDeveloperOnboardingEvents(): DeveloperOnboardingLocalEvent[] {
+  const events = getDeveloperOnboardingEvents();
+  if (typeof console.table === 'function') console.table(events);
+  else console.log(events);
+  return events;
+}
+
+if (typeof window !== 'undefined') {
+  (window as Window & { connectomeDeveloperOnboardingEvents?: typeof getDeveloperOnboardingEvents; logConnectomeDeveloperOnboardingEvents?: typeof logDeveloperOnboardingEvents }).connectomeDeveloperOnboardingEvents = getDeveloperOnboardingEvents;
+  (window as Window & { connectomeDeveloperOnboardingEvents?: typeof getDeveloperOnboardingEvents; logConnectomeDeveloperOnboardingEvents?: typeof logDeveloperOnboardingEvents }).logConnectomeDeveloperOnboardingEvents = logDeveloperOnboardingEvents;
+}
+
 export function trackDeveloperOnboardingEvent(eventType: DeveloperOnboardingEvent, value = 1): void {
+  storeLocalEvent(eventType, value);
+
   const token = localStorage.getItem(TOKEN_KEY);
   if (!token) return;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ import PathFeedMomentumLandingPage from './pages/PathFeedMomentumLandingPage'
 import PathFeedExamplesLandingPage from './pages/PathFeedExamplesLandingPage'
 import PathFeedReturnLoopLandingPage from './pages/PathFeedReturnLoopLandingPage'
 import ConnectomeBuildersLandingPage from './pages/ConnectomeBuildersLandingPage'
+import DailyAiCheckInLandingPage from './pages/DailyAiCheckInLandingPage'
 import ProfilePage from './pages/ProfilePage'
 import SurfacePage from './pages/SurfacePage'
 import IOOPage from './pages/IOOPage'
@@ -185,6 +186,7 @@ function App() {
           <Route path="/path-feed-momentum" element={<PathFeedMomentumLandingPage />} />
           <Route path="/path-feed-examples" element={<PathFeedExamplesLandingPage />} />
           <Route path="/path-feed-return-loop" element={<PathFeedReturnLoopLandingPage />} />
+          <Route path="/daily-ai-check-in" element={<DailyAiCheckInLandingPage />} />
           <Route path="/connectome-builders" element={<ConnectomeBuildersLandingPage />} />
           <Route path="/app/ioo" element={<ShellRoute activeApp="ioo"><IOOPage /></ShellRoute>} />
           <Route path="/app/ivive" element={<Navigate to="/app/ioo" replace />} />

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -200,6 +200,7 @@ export default function ContributePage() {
           </div>
           <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
             <PrimaryCTA href="https://github.com/AvielCarlos/connectome-backend/issues" target="_blank" rel="noreferrer" onClick={() => trackDeveloperOnboardingEvent('cp_issue_list_clicked')}>Browse CP issues →</PrimaryCTA>
+            <PrimaryCTA href="https://github.com/AvielCarlos/connectome-backend" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('backend_repo_clicked')}>View backend repo</PrimaryCTA>
             <PrimaryCTA href="https://github.com/AvielCarlos/connectome-web" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('web_repo_clicked')}>View web repo</PrimaryCTA>
             <PrimaryCTA href="https://t.me/ascensiontechai" target="_blank" rel="noreferrer" variant="secondary" onClick={() => trackDeveloperOnboardingEvent('community_clicked')}>Join community</PrimaryCTA>
           </div>

--- a/src/pages/DailyAiCheckInLandingPage.tsx
+++ b/src/pages/DailyAiCheckInLandingPage.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router-dom'
+
+const APP_LINK = '/auth?utm_source=owned_landing&utm_campaign=daily_ai_check_in'
+const EXAMPLES_LINK = '/path-feed-examples'
+const RETURN_LOOP_LINK = '/path-feed-return-loop'
+const BUILDERS_LINK = '/connectome-builders'
+
+const checkInSteps = [
+  {
+    title: 'Tell Aura what today feels like',
+    detail: 'A check-in should be fast: energy, constraints, location context, and the goal that matters most right now.',
+  },
+  {
+    title: 'Get one realistic next move',
+    detail: 'Connectome turns that context into a Path Feed card instead of a generic productivity list or infinite feed.',
+  },
+  {
+    title: 'Rate, save, complete, or skip',
+    detail: 'A tiny action closes the loop so tomorrow’s recommendations can become more useful and less noisy.',
+  },
+]
+
+const useCases = [
+  'You want a daily AI check-in that respects your actual day, not an abstract ideal schedule.',
+  'You are testing personal AI tools and care about activation, feedback, and return loops.',
+  'You are a builder looking for a narrow contribution path into AI OS / human flourishing infrastructure.',
+]
+
+function Panel({ children, accent = '#00d4aa' }: { children: React.ReactNode; accent?: string }) {
+  return (
+    <section style={{ background: 'linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.026))', border: `1px solid ${accent}34`, borderRadius: 26, padding: 24, boxShadow: '0 24px 70px rgba(0,0,0,0.25)' }}>
+      {children}
+    </section>
+  )
+}
+
+export default function DailyAiCheckInLandingPage() {
+  return (
+    <main style={{ minHeight: 'var(--visual-viewport-height, 100dvh)', background: '#060610', color: '#f8f8fc', position: 'relative', overflow: 'hidden' }}>
+      <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: 'radial-gradient(circle at 14% 12%, rgba(0,212,170,0.24), transparent 30rem), radial-gradient(circle at 86% 16%, rgba(129,140,248,0.24), transparent 32rem), radial-gradient(circle at 50% 108%, rgba(244,194,107,0.14), transparent 34rem)' }} />
+
+      <div style={{ position: 'relative', maxWidth: 1120, margin: '0 auto', padding: '28px 20px 76px' }}>
+        <nav style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16, marginBottom: 54 }}>
+          <Link to="/" style={{ color: '#f8f8fc', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 10, fontWeight: 950 }}>
+            <span style={{ width: 34, height: 34, borderRadius: 12, display: 'grid', placeItems: 'center', background: 'linear-gradient(135deg, rgba(0,212,170,0.28), rgba(129,140,248,0.32))', border: '1px solid rgba(0,212,170,0.35)' }}>◈</span>
+            <span>Connectome</span>
+          </Link>
+          <Link to={EXAMPLES_LINK} style={{ color: 'rgba(248,248,252,0.72)', textDecoration: 'none', fontSize: 14, fontWeight: 850 }}>See Path Feed examples →</Link>
+        </nav>
+
+        <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(310px, 1fr))', gap: 28, alignItems: 'center' }}>
+          <div>
+            <div style={{ color: '#00d4aa', fontSize: 12, fontWeight: 950, letterSpacing: 1.4, textTransform: 'uppercase', marginBottom: 16 }}>Daily AI check-in · Path Feed activation</div>
+            <h1 style={{ fontSize: 'clamp(42px, 7vw, 78px)', lineHeight: 0.96, letterSpacing: -3.5, margin: '0 0 20px', fontWeight: 950 }}>
+              A daily AI check-in should end in one useful action.
+            </h1>
+            <p style={{ fontSize: 20, lineHeight: 1.6, color: 'rgba(248,248,252,0.72)', maxWidth: 760, margin: '0 0 28px' }}>
+              Connectome is building a personal AI OS for human flourishing: a calm check-in, a contextual Path Feed, and a feedback loop that learns what actually helped.
+            </p>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              <Link to={APP_LINK} style={{ background: 'linear-gradient(135deg, #00d4aa, #818cf8)', color: '#07100f', padding: '15px 20px', borderRadius: 14, textDecoration: 'none', fontWeight: 950, boxShadow: '0 18px 44px rgba(0,212,170,0.18)' }}>
+                Try a check-in →
+              </Link>
+              <Link to={RETURN_LOOP_LINK} style={{ background: 'rgba(255,255,255,0.07)', border: '1px solid rgba(255,255,255,0.12)', color: '#f8f8fc', padding: '15px 20px', borderRadius: 14, textDecoration: 'none', fontWeight: 850 }}>
+                See the return loop
+              </Link>
+            </div>
+          </div>
+
+          <Panel accent="#818cf8">
+            <div style={{ color: '#a5b4fc', fontSize: 12, fontWeight: 950, letterSpacing: 1.4, textTransform: 'uppercase', marginBottom: 10 }}>What makes it different</div>
+            <h2 style={{ margin: '0 0 14px', fontSize: 32, letterSpacing: -1.1 }}>Less dashboard. More next move.</h2>
+            <p style={{ color: 'rgba(248,248,252,0.68)', lineHeight: 1.75, margin: 0 }}>
+              Most personal AI tools ask for lots of context and leave you with another interface to manage. Connectome’s first-session promise is narrower: show a useful card, ask for a clear signal, and improve from there.
+            </p>
+          </Panel>
+        </section>
+
+        <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(285px, 1fr))', gap: 18, marginTop: 24 }}>
+          {checkInSteps.map((step, index) => (
+            <Panel key={step.title}>
+              <div style={{ color: '#98ffe9', fontSize: 12, fontWeight: 950, letterSpacing: 1.2, textTransform: 'uppercase', marginBottom: 12 }}>{index + 1} · {step.title}</div>
+              <p style={{ color: 'rgba(248,248,252,0.76)', lineHeight: 1.7, margin: 0 }}>{step.detail}</p>
+            </Panel>
+          ))}
+        </section>
+
+        <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(310px, 1fr))', gap: 18, marginTop: 18 }}>
+          <Panel accent="#f4c26b">
+            <h2 style={{ fontSize: 28, letterSpacing: -1, margin: '0 0 16px' }}>Good fit if…</h2>
+            <ul style={{ margin: 0, paddingLeft: 20, color: 'rgba(248,248,252,0.72)', lineHeight: 1.75 }}>
+              {useCases.map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          </Panel>
+          <Panel accent="#00d4aa">
+            <h2 style={{ fontSize: 28, letterSpacing: -1, margin: '0 0 16px' }}>Builders welcome</h2>
+            <p style={{ color: 'rgba(248,248,252,0.72)', lineHeight: 1.75, margin: '0 0 16px' }}>
+              The public roadmap needs focused help on onboarding, Path Feed quality, contribution analytics, and safe agent UX. Contribution Points are recognition/reputation only — not cash, tokens, equity, or investment returns.
+            </p>
+            <Link to={BUILDERS_LINK} style={{ color: '#98ffe9', fontWeight: 900, textDecoration: 'none' }}>Open the builder path →</Link>
+          </Panel>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a new owned inbound landing page at /daily-ai-check-in for daily AI check-in and Path Feed activation traffic
- Link it from the README and sitemap
- Add GitHub Pages route fallback generation so direct links resolve cleanly

## No-spam / safety notes
- Owned/public inbound asset only; no direct outreach, DMs, emails, scraped lists, or repetitive promo
- CP language remains contribution recognition/reputation only, not cash/token/equity/investment promise

## Validation
- npm run build
- python3 scripts/guard_no_public_secrets.py