### PR TITLE
fix: prevent mobile shell chrome overlap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -662,7 +662,7 @@ body {
 
 .connectome-app-titlebar {
   position: fixed;
-  top: calc(var(--top-header-height) + 12px);
+  top: var(--shell-top-clearance);
   left: 50%;
   transform: translateX(-50%);
   z-index: 35;
@@ -974,7 +974,7 @@ body.keyboard-open .global-feedback-fab {
   bottom: var(--shell-bottom-clearance) !important;
 }
 .aura-container {
-  top: var(--top-header-height) !important;
+  top: var(--shell-top-clearance) !important;
   left: 0 !important;
   right: 0 !important;
   bottom: calc(var(--bottom-nav-height, 72px) + max(14px, env(safe-area-inset-bottom, 0px)) + 14px) !important;

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1923,7 +1923,7 @@ export default function FeedPage() {
       {/* ── Difficulty switcher — centred at top ─────────────────────────── */}
       <div style={{
         position: 'absolute',
-        top: 'calc(env(safe-area-inset-top, 0px) + var(--shell-top-clearance, 52px) + 10px)',
+        top: 'max(10px, env(safe-area-inset-top, 0px))',
         left: 0, right: 0,
         zIndex: 20,
         display: 'flex',


### PR DESCRIPTION
## Summary

Prevents mobile Connectome shell chrome from overlapping app content by routing fixed app surfaces through the measured shell clearance instead of the static header height.

## Changes

- Use `--shell-top-clearance` for fixed app titlebars and the Aura fixed container.
- Keep the iDo feed difficulty switcher positioned relative to the feed viewport instead of adding shell clearance twice.

## Testing

- `npm run build`
- `python3 scripts/guard_no_public_secrets.py`

Fixes AvielCarlos/connectome-web#37