### PR TITLE
feat: separate system operator route boundary

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -177,7 +177,8 @@ function App() {
           <Route path="/app/dao" element={<ShellRoute activeApp="dao"><DAOPage /></ShellRoute>} />
           <Route path="/app/contribute" element={<ShellRoute activeApp="contribute"><ContributePage /></ShellRoute>} />
           <Route path="/app/profile" element={<ShellRoute activeApp="profile"><ProfilePage /></ShellRoute>} />
-          <Route path="/app/admin" element={<ShellRoute activeApp="profile"><ProfilePage initialSection="admin" /></ShellRoute>} />
+          <Route path="/app/admin" element={<ShellRoute activeApp="admin"><ProfilePage initialSection="admin" /></ShellRoute>} />
+          <Route path="/app/system" element={<ShellRoute activeApp="admin"><ProfilePage initialSection="system" /></ShellRoute>} />
           <Route path="/app/billing/success" element={<ShellRoute activeApp="profile"><PaymentSuccessPage /></ShellRoute>} />
           <Route path="/app/journal" element={<Navigate to="/app/discovery" replace />} />
           <Route path="/app/services" element={<ShellRoute activeApp="services"><ServicesPage /></ShellRoute>} />
@@ -212,6 +213,7 @@ function App() {
           <Route path="/contribute" element={<Navigate to="/app/contribute" replace />} />
           <Route path="/profile" element={<Navigate to="/app/profile" replace />} />
           <Route path="/admin" element={<Navigate to="/app/admin" replace />} />
+          <Route path="/system" element={<Navigate to="/app/system" replace />} />
           <Route path="/ioo" element={<Navigate to="/app/ioo" replace />} />
 
           {/* WebSpawn surfaces — auth-gated but accessible via direct link */}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1522,9 +1522,19 @@ export default function ProfilePage({ initialSection = 'profile' }: ProfilePageP
         </div>
       )}
 
-      {/* ── Admin tier testing section ── */}
+      {/* ── Admin route hub + tier testing section ── */}
       {section === 'admin' && isAdmin && profile?.email?.toLowerCase() === 'carlosandromeda8@gmail.com' && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <Card title="Operator routes">
+            <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.55)', lineHeight: 1.6, marginBottom: 12 }}>
+              System tools live on explicit operator routes. Profile remains the user/account surface.
+            </div>
+            <div style={{ display: 'grid', gap: 8 }}>
+              <MenuRow icon="⚡" label="System tools" sublabel="Autonomy, health dashboard, proposals, and agent population" onClick={() => navigate('/app/system')} />
+              <MenuRow icon="⚗️" label="Experiments" sublabel="A/B tests, winners, and live experiment diagnostics" onClick={() => setSection('experiments')} />
+              <MenuRow icon="🏛️" label="Executive council" sublabel="Council brief, agent runs, and operating metrics" onClick={() => { setSection('council'); loadCouncilData(); }} last />
+            </div>
+          </Card>
           <Card title="Tier testing & feed reset">
             <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.55)', lineHeight: 1.6, marginBottom: 14 }}>
               Switch your account between tiers to test upgrade gates, then reset the Path Feed counter so the next feed load starts fresh.
@@ -1563,6 +1573,14 @@ export default function ProfilePage({ initialSection = 'profile' }: ProfilePageP
         <Card title="Admin controls">
           <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.58)', lineHeight: 1.6 }}>
             This is a protected system route. Your normal Profile stays separate at /app/profile; admin controls only appear for authorised operator accounts.
+          </div>
+        </Card>
+      )}
+
+      {section === 'system' && !isAdmin && (
+        <Card title="System tools">
+          <div style={{ fontSize: 13, color: 'rgba(248,248,252,0.58)', lineHeight: 1.6 }}>
+            This is a protected system route. Your normal Profile stays separate at /app/profile; system controls only appear for authorised operator accounts.
           </div>
         </Card>
       )}

--- a/src/runtime/ontology.ts
+++ b/src/runtime/ontology.ts
@@ -47,7 +47,8 @@ export type AppId =
   | 'contribute'
   | 'services'
   | 'ioo'
-  | 'profile';
+  | 'profile'
+  | 'admin';
 
 export type AppCategory = 'daily' | 'domain' | 'system' | 'governance';
 export type FeedOwner = 'ido_meta_feed' | 'ivive_domain_feed' | 'eviva_domain_feed' | 'aventi_domain_feed' | 'dao_signal_feed';
@@ -495,6 +496,17 @@ export const APP_MANIFEST: AppManifestEntry[] = [
     permissions: ['memory', 'dao'],
     description: 'User-facing Path Map over Aura’s internal IOO graph: goals, options, steps, and progress toward desired states.',
     purpose: 'Lets users see possible routes from current state to success without exposing internal graph machinery by default.',
+  },
+  {
+    id: 'admin',
+    name: 'System',
+    icon: '⚙️',
+    path: '/app/admin',
+    category: 'system',
+    visibleToUser: false,
+    permissions: ['memory', 'files', 'notifications'],
+    description: 'Protected operator controls, diagnostics, experiments, and Aura self-improvement surfaces.',
+    purpose: 'Keeps system-level tools behind an explicit route boundary instead of mixing them into the user Profile surface.',
   },
   {
     id: 'profile',

--- a/src/shell/ConnectomeShell.tsx
+++ b/src/shell/ConnectomeShell.tsx
@@ -19,6 +19,7 @@ interface ConnectomeShellProps {
 function appLabel(appId: ShellApp) {
   if (appId === 'home') return 'Aura';
   if (appId === 'ido') return 'Discover';
+  if (appId === 'admin') return 'System';
   return appById(appId)?.name || 'Aura';
 }
 
@@ -48,6 +49,7 @@ const dockMenus: Partial<Record<ShellApp, DockItem[]>> = {
   services: CORE_DOCK,
   ioo: CORE_DOCK,
   profile: CORE_DOCK,
+  admin: CORE_DOCK,
 };
 
 function initials(profile: any) {


### PR DESCRIPTION
## Summary

Continues the Profile/Admin route split from issue #18 by making system tools an explicit operator route instead of another Profile sub-view.

## Changes

- Adds `/app/system` with a protected non-admin boundary message.
- Marks `/app/admin` as the `System` shell context instead of `Profile`.
- Adds a hidden `admin` app manifest entry so shell labels and route context reflect the operator boundary.
- Adds an operator hub from Admin Controls to System tools, Experiments, and Executive Council.

## Testing

- `npm run build` passed.
- `git diff --check` passed.
- `python3 scripts/guard_no_public_secrets.py` passed.

Continues AvielCarlos/connectome-web#18.
