### PR TITLE
feat: add IOO graph tooltip

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -298,6 +298,67 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 /* ─── Tooltip ───────────────────────────────────────────────────────── */
 .tooltip { position: relative; }
 
+.ioo-graph-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,212,170,0.35);
+  color: #00d4aa;
+  background: rgba(0,212,170,0.08);
+  font-size: 13px;
+  font-weight: 800;
+  cursor: help;
+  outline: none;
+}
+
+.ioo-graph-tooltip:focus-visible {
+  box-shadow: 0 0 0 3px rgba(0,212,170,0.2);
+}
+
+.tooltip-card {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 10px);
+  transform: translateX(-50%) translateY(-4px);
+  z-index: 20;
+  width: min(280px, calc(100vw - 48px));
+  padding: 12px 14px;
+  border: 1px solid rgba(0,212,170,0.22);
+  border-radius: 14px;
+  background: rgba(12,14,20,0.96);
+  box-shadow: 0 16px 40px rgba(0,0,0,0.35);
+  color: rgba(248,248,252,0.78);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.tooltip-card::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  transform: translateX(-50%) rotate(45deg);
+  border-left: 1px solid rgba(0,212,170,0.22);
+  border-top: 1px solid rgba(0,212,170,0.22);
+  background: rgba(12,14,20,0.96);
+}
+
+.tooltip:hover .tooltip-card,
+.tooltip:focus-visible .tooltip-card,
+.tooltip:focus-within .tooltip-card {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
 /* ─── Gamification / Celebration ───────────────────────────────────── */
 @keyframes streakFlame {
   0%   { transform: scale(1) rotate(-4deg); }

--- a/src/pages/IOOPage.tsx
+++ b/src/pages/IOOPage.tsx
@@ -351,9 +351,21 @@ export default function IOOPage() {
     <div className="page-content" style={containerStyle}>
       {/* Header */}
       <div style={{ marginBottom: 32 }}>
-        <h1 style={{ fontSize: 26, fontWeight: 800, margin: 0, letterSpacing: -0.5 }}>
-          🧬 IOO Neural Graph
-        </h1>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          <h1 style={{ fontSize: 26, fontWeight: 800, margin: 0, letterSpacing: -0.5 }}>
+            🧬 IOO Neural Graph
+          </h1>
+          <span
+            className="tooltip ioo-graph-tooltip"
+            tabIndex={0}
+            aria-label="The IOO graph is Aura’s living map of goals, prerequisites, actions, tools, services, and state transitions."
+          >
+            ?
+            <span className="tooltip-card" role="tooltip">
+              Aura uses this graph to understand what helps you move from intention to fulfilment — then pick the next card, pathway, agent, or real-world step.
+            </span>
+          </span>
+        </div>
         <p style={{ fontSize: 14, color: 'rgba(248,248,252,0.55)', marginTop: 6, marginBottom: 0, lineHeight: 1.55 }}>
           This is Aura’s internal map of human possibility: goals, prerequisites, actions, tools, services, and state transitions. It should help Connectome choose your next best card, pathway, agent, or real-world step.
         </p>


### PR DESCRIPTION
## Summary

Adds an accessible tooltip beside the IOO Neural Graph title so users can quickly understand what Aura's graph represents and how it guides next-step recommendations.

## Changes

- Adds a keyboard-focusable help badge to the IOO graph header.
- Adds reusable tooltip styling for hover and focus-visible states.
- Frames the graph as Aura's living map from intention to fulfilment.

## Testing

- `npm run build`
- `python3 scripts/guard_no_public_secrets.py`

Fixes AvielCarlos/connectome-web#116