### PR TITLE
fix(profile): keep operator back navigation in route context

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -85,6 +85,18 @@ const getAdminHeaders = () => {
 
 export default function ProfilePage({ initialSection = 'profile' }: ProfilePageProps = {}) {
   const navigate = useNavigate();
+  const routeRootSection: ProfileSection = initialSection === 'admin' || initialSection === 'system' ? initialSection : 'profile';
+  const handleSectionBack = () => {
+    if (section !== routeRootSection) {
+      setSection(routeRootSection);
+      return;
+    }
+    if (routeRootSection === 'system') {
+      navigate('/app/admin');
+      return;
+    }
+    navigate('/app/profile');
+  };
   const { logout, refreshProfile } = useAuth();
   const [profile, setProfile] = useState<any>(null);
   const [loading, setLoading] = useState(true);
@@ -627,7 +639,7 @@ export default function ProfilePage({ initialSection = 'profile' }: ProfilePageP
       {section !== 'profile' && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 }}>
           <button
-            onClick={() => initialSection === 'profile' ? setSection('profile') : navigate('/app/profile')}
+            onClick={handleSectionBack}
             style={{
               display: 'flex', alignItems: 'center', gap: 6,
               background: 'transparent', border: 'none', cursor: 'pointer',


### PR DESCRIPTION
## Summary\n- Keep nested Admin route sections (Experiments, Executive Council) returning to the Admin Controls hub instead of dropping the operator back into Profile.\n- Keep nested System route sections returning to System, with the System root back button returning to the Admin hub.\n- Preserves normal Profile sub-section back behaviour.\n\n## Why\nSmall route-boundary cleanup for #18. It makes the Profile/Admin/System split less confusing without changing permissions or exposing new admin surfaces.\n\n## Verification\n- npm run build\n- git diff --check\n- python3 scripts/guard_no_public_secrets.py\n\nCloses part of #18