### PR TITLE
fix: separate system navigation from profile

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -51,13 +51,6 @@ export function NavBar() {
   const [navVisible, setNavVisible] = useState(true);
   const [moreMenu, setMoreMenu] = useState<'me' | 'map' | null>(null);
 
-  // More menu items for Me tab
-  const ME_MORE = [
-    { path: '/app/dao',        icon: '🏛', label: 'DAO & Contributions' },
-    { path: '/app/contribute', icon: '✚', label: 'Contribute & Earn' },
-    { path: '/app',       icon: '◉', label: 'Home' },
-  ];
-
   const MAP_MORE = [
     { path: '/ioo',      icon: '🗺', label: 'IOO Map' },
     { path: '/app/goals',    icon: '◎', label: 'Goals' },
@@ -69,6 +62,15 @@ export function NavBar() {
   const tierColor = TIER_COLORS[tier] || '#6b7280';
   const initials = ((profile as any)?.display_name || (profile as any)?.email || 'U')[0].toUpperCase();
   const isAdmin = (profile as any)?.is_admin || (profile as any)?.profile?.is_admin;
+  const sidebarItems = isAdmin
+    ? [...SIDEBAR_ITEMS, { path: '/app/admin', icon: '⚙️', label: 'System', isAdmin: true }]
+    : SIDEBAR_ITEMS;
+  const meMore = [
+    ...(isAdmin ? [{ path: '/app/admin', icon: '⚙️', label: 'System tools' }] : []),
+    { path: '/app/dao',        icon: '🏛', label: 'DAO & Contributions' },
+    { path: '/app/contribute', icon: '✚', label: 'Contribute & Earn' },
+    { path: '/app',       icon: '◉', label: 'Home' },
+  ];
 
   // Nav always visible — no hide on scroll
 
@@ -106,7 +108,7 @@ export function NavBar() {
 
         {/* Nav links */}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {SIDEBAR_ITEMS.map((item) => (
+          {sidebarItems.map((item) => (
             <NavLink key={item.path} to={item.path} style={({ isActive }) => ({
               display: 'flex', alignItems: 'center', gap: 12,
               padding: '10px 14px', borderRadius: 12,
@@ -183,7 +185,7 @@ export function NavBar() {
             borderRadius: 16, overflow: 'hidden', minWidth: 220,
             boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
           }}>
-            {(moreMenu === 'me' ? ME_MORE : MAP_MORE).map((item, i, arr) => (
+            {(moreMenu === 'me' ? meMore : MAP_MORE).map((item, i, arr) => (
               <button key={item.path} onClick={() => { navigate(item.path); setMoreMenu(null); }} style={{
                 width: '100%', display: 'flex', alignItems: 'center', gap: 12,
                 padding: '14px 18px', background: 'none', border: 'none',

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -982,12 +982,6 @@ export default function ProfilePage({ initialSection = 'profile' }: ProfilePageP
             <MenuRow icon="📱" label="Get the App" sublabel="Add Connectome to your home screen" onClick={() => {}} last />
           </div>
 
-          {isAdmin && profile?.email?.toLowerCase() === 'carlosandromeda8@gmail.com' && (
-            <div style={{ background: '#12121e', border: '1px solid rgba(168,85,247,0.18)', borderRadius: 16, overflow: 'hidden' }}>
-              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1, color: 'rgba(168,85,247,0.8)', textTransform: 'uppercase', padding: '14px 18px 6px' }}>Admin</div>
-              <MenuRow icon="⚙️" label="Admin controls" sublabel="Tier testing, system tools, and protected operations" onClick={() => navigate('/app/admin')} last />
-            </div>
-          )}
 
           {/* ── Sign Out ── */}
           <button onClick={handleLogout} style={{

--- a/src/shell/AppLauncher.tsx
+++ b/src/shell/AppLauncher.tsx
@@ -25,7 +25,7 @@ const OUTCOME_LABELS: Partial<Record<ConnectomeApp['id'], { title: string; descr
   dao: { title: 'Understand the DAO', description: 'See governance, CP, proposals, and the contribution economy.', badge: 'DAO' },
   contribute: { title: 'Submit work and earn CP', description: 'Share code, design, research, ideas, or feedback for review.', badge: 'Build' },
   ioo: { title: 'Open your Path Map', description: 'See user-friendly routes from your current state to your desired goals and experiences.', badge: 'Map' },
-  profile: { title: 'Manage identity and settings', description: 'Control profile, accounts, permissions, experiments, and system tools.', badge: 'You' },
+  profile: { title: 'Manage identity and settings', description: 'Control profile, accounts, permissions, personal context, and billing.', badge: 'You' },
 };
 
 export default function AppLauncher({ onLaunch }: AppLauncherProps) {


### PR DESCRIPTION
## Summary

Tightens the Profile/Admin route boundary for #18 by keeping operator entry points in explicit System navigation instead of inside the user Profile settings list.

## Changes

- Adds a protected System entry to desktop navigation for admin/operator accounts.
- Adds System tools to the mobile Me overflow only for admin/operator accounts.
- Removes the Admin controls block from the Profile page so Profile stays focused on identity/account/contribution settings.
- Updates app-launcher Profile copy to avoid presenting experiments/system tools as part of the user profile surface.

## Testing

- `npm run build`
- `python3 scripts/guard_no_public_secrets.py`
- `git diff --check`

## Visual verification

No screenshot attached from this cron run; this is a small navigation/copy boundary change and build/typecheck passed. Please visually verify `/app/profile`, `/app/admin`, and the mobile Me overflow before merge.

Fixes #18
